### PR TITLE
Feature/test01

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -151,7 +151,7 @@ jobs:
             RESPONSE=$(curl -s -X POST \
               -H "Authorization: token $GITHUB_TOKEN" \
               -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/${{ github.repository }}/issues/2/comments" \
+              "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
               -d "{\"body\": \"![Diff Image $(basename \"$file\")]()\"}")
 
             URL=$(echo "$RESPONSE" | jq -r '.body' | grep -Eo 'https://user-images.githubusercontent.com[^)]+' | head -n1)
@@ -159,11 +159,13 @@ jobs:
             COMMENT_BODY+="![Diff Image $(basename \"$file\")]($URL)\n\n"
           done
 
+          ESCAPED_BODY=$(echo "$COMMENT_BODY" | jq -Rs .)
+
           curl -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/2/comments" \
-            -d "{\"body\": \"$COMMENT_BODY\"}"
+            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            -d "{\"body\": $ESCAPED_BODY}"
 
       # Issueにあげて公開URLを取得すると良さそう
       - name: Cache VRT snapshots

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -142,6 +142,27 @@ jobs:
           BASE_URL="https://raw.githubusercontent.com/${REPO}/${BRANCH}/artifacts"
           COMMENT="### Snapshot Test Results\n"
 
+          # success ディレクトリ内の画像リンクを追加
+          COMMENT+="\n**Success:**\n"
+          for file in artifacts/success/*.png; do
+            filename=$(basename "$file")
+            COMMENT+="- [${filename}](${BASE_URL}/success/${filename})\n"
+          done
+
+          # failed ディレクトリ内の画像リンクを追加
+          COMMENT+="\n**Failed:**\n"
+          for file in artifacts/failed/*.png; do
+            filename=$(basename "$file")
+            COMMENT+="- [${filename}](${BASE_URL}/failed/${filename})\n"
+          done
+
+          # diffs ディレクトリ内の画像リンクを追加
+          COMMENT+="\n**Diffs:**\n"
+          for file in artifacts/diffs/*.png; do
+            filename=$(basename "$file")
+            COMMENT+="- [${filename}](${BASE_URL}/diffs/${filename})\n"
+          done
+
           echo "$COMMENT" > comment.md
           echo "::set-output name=body::$(cat comment.md)"
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -138,35 +138,35 @@ jobs:
           BASE_URL="https://raw.githubusercontent.com/${REPO}/${BRANCH}/artifacts"
           
           comment=$(cat <<'EOF'
-<table>
-  <thead>
-    <tr>
-      <th>既存</th>
-      <th>差分</th>
-      <th>今回</th>
-    </tr>
-  </thead>
-  <tbody>
-EOF
-)
+          <table>
+            <thead>
+              <tr>
+                <th>既存</th>
+                <th>差分</th>
+                <th>今回</th>
+              </tr>
+            </thead>
+            <tbody>
+          EOF
+          )
           found=0
           for file in artifacts/success/*.png; do
-            found=1
-            filename=$(basename "$file")
-            comment+=$(cat <<EOF
-    <tr>
-      <td><img src="${BASE_URL}/success/${filename}" width="300"></td>
-      <td><img src="${BASE_URL}/diffs/${filename}" width="300"></td>
-      <td><img src="${BASE_URL}/failed/${filename}" width="300"></td>
-    </tr>
-EOF
-)
+          found=1
+          filename=$(basename "$file")
+          comment+=$(cat <<EOF
+              <tr>
+                <td><img src="${BASE_URL}/success/${filename}" width="300"></td>
+                <td><img src="${BASE_URL}/diffs/${filename}" width="300"></td>
+                <td><img src="${BASE_URL}/failed/${filename}" width="300"></td>
+              </tr>
+          EOF
+          )
           done
           if [ $found -eq 0 ]; then
             comment+="    <tr><td colspan='3'>No images found</td></tr>"
           fi
           comment+="  </tbody>
-</table>"
+          </table>"
           echo "$comment" > comment.md
           echo "::set-output name=body::$(cat comment.md)"
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -117,7 +117,7 @@ jobs:
           path: artifacts/failed/*.png
 
       - name: 比較用ブランチ作成 & 画像をコミット
-        if: failure()
+        if: ${{ failure() }}
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
@@ -128,7 +128,7 @@ jobs:
           git push origin comparison-screenshots --force
 
       - name: コメント本文を生成
-        if: failure()
+        if: ${{ failure() }}
         id: generate_comment
         shell: bash
         run: |
@@ -137,7 +137,22 @@ jobs:
           BRANCH=comparison-screenshots
           BASE_URL="https://raw.githubusercontent.com/${REPO}/${BRANCH}/artifacts"
           
-          comment=$(cat <<'EOF'
+          # rows 変数に各画像のテーブル行を連結
+          rows=""
+          for file in artifacts/success/*.png; do
+            filename=$(basename "$file")
+            rows="${rows}    <tr>\n"
+            rows="${rows}      <td><img src=\"${BASE_URL}/success/${filename}\" width=\"300\"></td>\n"
+            rows="${rows}      <td><img src=\"${BASE_URL}/diffs/${filename}\" width=\"300\"></td>\n"
+            rows="${rows}      <td><img src=\"${BASE_URL}/failed/${filename}\" width=\"300\"></td>\n"
+            rows="${rows}    </tr>\n"
+          done
+          if [ -z "$rows" ]; then
+            rows="    <tr><td colspan='3'>No images found</td></tr>\n"
+          fi
+
+          # ヒアドキュメントでテーブル全体を生成
+          comment=$(cat <<EOF
           <table>
             <thead>
               <tr>
@@ -147,31 +162,15 @@ jobs:
               </tr>
             </thead>
             <tbody>
+          ${rows}  </tbody>
+          </table>
           EOF
           )
-          found=0
-          for file in artifacts/success/*.png; do
-          found=1
-          filename=$(basename "$file")
-          comment+=$(cat <<EOF
-              <tr>
-                <td><img src="${BASE_URL}/success/${filename}" width="300"></td>
-                <td><img src="${BASE_URL}/diffs/${filename}" width="300"></td>
-                <td><img src="${BASE_URL}/failed/${filename}" width="300"></td>
-              </tr>
-          EOF
-          )
-          done
-          if [ $found -eq 0 ]; then
-            comment+="    <tr><td colspan='3'>No images found</td></tr>"
-          fi
-          comment+="  </tbody>
-          </table>"
           echo "$comment" > comment.md
           echo "::set-output name=body::$(cat comment.md)"
 
       - name: PR にコメント投稿
-        if: failure()
+        if: ${{ failure() }}
         uses: peter-evans/create-or-update-comment@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -170,42 +170,44 @@ jobs:
         run: |
           RELEASE_URL="https://github.com/${{ github.repository }}/releases/download/snapshot-diff"
       
-          # コメント本文を printf で改行付きで構築（printf は自動で改行を入れる）
+          # コメント本文の構築
           COMMENT_BODY=$(cat <<EOF
           🚨 **Snapshotテストで差分が発生しています** 🚨
-
+    
           以下に画像の差分を表示します。
-
+    
           詳細な画像はこちらからダウンロードしてください。
           [📥 Artifactsをダウンロード](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)
-
+    
           EOF
           )
-
-          COUNT=1
-          for file in artifacts/diffs/*.png; do
-            IMAGE_URL="$RELEASE_URL/$(basename "$file")"
-
-            COMMENT_BODY+=$(cat <<EOF
-
+    
+              COUNT=1
+              for file in artifacts/diffs/*.png; do
+                BASENAME=$(basename "$file")
+                DIFF_IMAGE_URL="$RELEASE_URL/$BASENAME"
+                SUCCESS_IMAGE_URL="$RELEASE_URL/success_${BASENAME#diff_}"
+                FAILED_IMAGE_URL="$RELEASE_URL/failed_${BASENAME#diff_}"
+    
+                COMMENT_BODY+=$(cat <<EOF
+    
           ### 画像${COUNT}
-
-          | 既存 | 差分 | 新規 |
+    
+          | 既存（成功時） | 差分 | 新規（失敗時） |
           | -- | -- | -- |
-          | 空 | <img src="${IMAGE_URL}" width="300"> | 空 |
-
+          | <img src="${SUCCESS_IMAGE_URL}" width="300"> | <img src="${DIFF_IMAGE_URL}" width="300"> | <img src="${FAILED_IMAGE_URL}" width="300"> |
+    
           EOF
           )
-
-            COUNT=$((COUNT + 1))
-          done
-
-          # JSONエスケープを適用し GitHub API に送信
-          curl -X POST \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-            -d "$(jq -Rs --arg body "$COMMENT_BODY" '{body: $body}' <<< "")"
+                COUNT=$((COUNT + 1))
+              done
+    
+              # JSONエスケープを適用し GitHub API に送信
+              curl -X POST \
+                -H "Authorization: token $GITHUB_TOKEN" \
+                -H "Accept: application/vnd.github+json" \
+                "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+                -d "$(jq -Rs --arg body "$COMMENT_BODY" '{body: $body}' <<< "")"
 
       # Issueにあげて公開URLを取得すると良さそう
       - name: Cache VRT snapshots

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -117,6 +117,7 @@ jobs:
           path: artifacts/failed/*.png
 
       - name: 比較用ブランチ作成 & 画像をコミット
+        if: failure()
         run: |
           # Git のユーザー設定（必要に応じて）
           git config --global user.name "GitHub Actions"
@@ -131,6 +132,7 @@ jobs:
           git push origin comparison-screenshots --force
 
       - name: コメント本文を生成
+        if: failure()
         id: generate_comment
         shell: bash
         run: |
@@ -140,31 +142,11 @@ jobs:
           BASE_URL="https://raw.githubusercontent.com/${REPO}/${BRANCH}/artifacts"
           COMMENT="### Snapshot Test Results\n"
 
-          # success ディレクトリ内の画像リンクを追加
-          COMMENT+="\n**Success:**\n"
-          for file in artifacts/success/*.png; do
-            filename=$(basename "$file")
-            COMMENT+="- [${filename}](${BASE_URL}/success/${filename})\n"
-          done
-
-          # failed ディレクトリ内の画像リンクを追加
-          COMMENT+="\n**Failed:**\n"
-          for file in artifacts/failed/*.png; do
-            filename=$(basename "$file")
-            COMMENT+="- [${filename}](${BASE_URL}/failed/${filename})\n"
-          done
-
-          # diffs ディレクトリ内の画像リンクを追加
-          COMMENT+="\n**Diffs:**\n"
-          for file in artifacts/diffs/*.png; do
-            filename=$(basename "$file")
-            COMMENT+="- [${filename}](${BASE_URL}/diffs/${filename})\n"
-          done
-
           echo "$COMMENT" > comment.md
           echo "::set-output name=body::$(cat comment.md)"
 
       - name: PR にコメント投稿
+        if: failure()
         uses: peter-evans/create-or-update-comment@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -228,23 +228,37 @@ jobs:
       
           CHECK_ID=$(echo "$CHECK_RUN" | jq -r '.id')
       
-          # コメント用変数
+          # コメント用変数（JSONエスケープ対応）
           CHECK_TITLE="🚨 Snapshotテストで差分が発生しました 🚨"
           CHECK_SUMMARY="🚨 **Snapshotテストで差分が発生しました** 🚨\n\n以下に詳細な画像の差分を表示します。\n\n"
       
-          # Annotations（行ごとのコメント）
+          # GitHub Checks の `annotations`
           ANNOTATIONS=()
       
           for file in artifacts/diffs/*.png; do
             BASENAME=$(basename "$file")
             FILENAME=${BASENAME#diff_}
       
-            # 画像のBase64エンコード
-            DIFF_B64=$(base64 "$file" | tr -d '\n')
-            SUCCESS_B64=$(base64 "artifacts/success/$FILENAME" | tr -d '\n')
-            FAILED_B64=$(base64 "artifacts/failed/$FILENAME" | tr -d '\n')
+            # macOS の `base64` は `-w 0` ではなく `tr -d '\n'` を使う
+            if [ -f "$file" ]; then
+              DIFF_B64=$(base64 "$file" | tr -d '\n')
+            else
+              DIFF_B64=""
+            fi
       
-            # GitHub Checks に表示するMarkdownテーブルを作成（Annotations用）
+            if [ -f "artifacts/success/$FILENAME" ]; then
+              SUCCESS_B64=$(base64 "artifacts/success/$FILENAME" | tr -d '\n')
+            else
+              SUCCESS_B64=""
+            fi
+      
+            if [ -f "artifacts/failed/$FILENAME" ]; then
+              FAILED_B64=$(base64 "artifacts/failed/$FILENAME" | tr -d '\n')
+            else
+              FAILED_B64=""
+            fi
+      
+            # 画像テーブル
             IMAGE_TABLE="### ${FILENAME}\n\n"
             IMAGE_TABLE+="| 既存（成功時） | 差分 | 新規（失敗時） |\n"
             IMAGE_TABLE+="| -- | -- | -- |\n"
@@ -261,12 +275,15 @@ jobs:
               '{path: $path, message: $message, annotation_level: $annotation_level, title: $title}')")
           done
       
+          # JSONエスケープ（エラー回避）
+          ESCAPED_SUMMARY=$(jq -Rs . <<< "$CHECK_SUMMARY")
+      
           # GitHub Checks を更新（Annotations を含める）
           curl -s -X PATCH \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             "$GITHUB_API/$CHECK_ID" \
-            -d "$(jq -n --arg status "completed" --arg conclusion "failure" --arg title "$CHECK_TITLE" --arg summary "$CHECK_SUMMARY" \
+            -d "$(jq -n --arg status "completed" --arg conclusion "failure" --arg title "$CHECK_TITLE" --arg summary "$ESCAPED_SUMMARY" \
               --argjson annotations "[${ANNOTATIONS[*]}]" \
               '{status: $status, conclusion: $conclusion, output: {title: $title, summary: $summary, annotations: $annotations}}')"
       

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -139,11 +139,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           COMMENT_BODY="🚨 **Snapshotテストで差分が発生しています** 🚨\n\n"
-          RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/snapshot-diff"
+          RELEASE_URL="https://github.com/${{ github.repository }}/releases/download/snapshot-diff"
       
           for file in artifacts/diffs/*.png; do
             IMAGE_URL="$RELEASE_URL/$(basename "$file")"
-            COMMENT_BODY+="![Diff Image $(basename "$file")]($IMAGE_URL)\n\n"
+            COMMENT_BODY+="<img src=\"$IMAGE_URL\" width=\"300\">\n\n"
           done
       
           curl -X POST \

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -141,6 +141,7 @@ jobs:
 #          echo "RELEASE_ID=$RELEASE_ID" >> $GITHUB_ENV
 
       - name: Create GitHub Issue for Snapshot Failures
+        if: failure()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -127,20 +127,45 @@ jobs:
           git commit -m "Add snapshot test screenshots for comparison"
           git push origin comparison-screenshots --force
 
+      - name: 比較用ブランチ作成 & 画像をコミット
+        if: ${{ failure() }}
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          git checkout --orphan comparison-screenshots
+          git reset --hard
+          git add artifacts
+          git commit -m "Add snapshot test screenshots for comparison"
+          git push origin comparison-screenshots --force
+
       - name: コメント本文を生成
         if: ${{ failure() }}
         id: generate_comment
         shell: bash
         run: |
           shopt -s nullglob
+          # 各ディレクトリ内のファイル名のユニオンを作成
+          declare -A files
+          for file in artifacts/success/*.png; do
+            filename=$(basename "$file")
+            files["$filename"]=1
+          done
+          for file in artifacts/diffs/*.png; do
+            filename=$(basename "$file")
+            files["$filename"]=1
+          done
+          for file in artifacts/failed/*.png; do
+            filename=$(basename "$file")
+            files["$filename"]=1
+          done
+          
           REPO=${GITHUB_REPOSITORY}
           BRANCH=comparison-screenshots
           BASE_URL="https://raw.githubusercontent.com/${REPO}/${BRANCH}/artifacts"
           
-          # diff 画像を基準にテーブル行を生成
           rows=""
-          for file in artifacts/diffs/*.png; do
-            filename=$(basename "$file")
+          # 集めた全ファイル名について行を生成
+          for filename in "${!files[@]}"; do
             rows="${rows}"$'    <tr>\n'
             rows="${rows}"$'      <td><img src="'${BASE_URL}'/success/'${filename}'" width="300"></td>\n'
             rows="${rows}"$'      <td><img src="'${BASE_URL}'/diffs/'${filename}'" width="300"></td>\n'

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -141,29 +141,27 @@ jobs:
 #          echo "RELEASE_ID=$RELEASE_ID" >> $GITHUB_ENV
 
       - name: Create GitHub Issue for Snapshot Failures
-        if: failure()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Creating GitHub Issue..."
+
+          # GitHub CLI のバージョンと認証状態を確認
+          gh --version
+          gh auth status
           
+          # Issue 作成を試行
           ISSUE_OUTPUT=$(gh issue create --title "Snapshot Test Failures" --body "Snapshot tests failed. See the images below." --label snapshot-test --repo ${{ github.repository }} 2>&1)
+          EXIT_CODE=$?
 
-          if [[ $? -ne 0 ]]; then
-            echo "Error: Failed to create issue"
-            echo "$ISSUE_OUTPUT"
+          echo "Issue command output: $ISSUE_OUTPUT"
+          
+          if [[ $EXIT_CODE -ne 0 ]]; then
+            echo "Error: Failed to create issue (Exit Code: $EXIT_CODE)"
             exit 1
           fi
 
-          # 作成した Issue の URL を取得
-          ISSUE_URL=$(gh issue list --repo ${{ github.repository }} --state open --limit 1 --json url --jq '.[0].url')
-
-          if [[ -z "$ISSUE_URL" ]]; then
-            echo "Error: Could not retrieve issue URL"
-            exit 1
-          fi
-
-          echo "Issue created: $ISSUE_URL"
+          echo "Issue successfully created!"
 
       - name: Upload success, failed, and diff images to GitHub Issue
         if: failure()

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -229,7 +229,8 @@ jobs:
           CHECK_ID=$(echo "$CHECK_RUN" | jq -r '.id')
       
           # コメント用変数（JSONエスケープ対応）
-          CHECK_SUMMARY=$(jq -n --arg text "🚨 **Snapshotテストで差分が発生しました** 🚨\n\n" '{summary: $text}')
+          CHECK_TITLE="🚨 Snapshotテストで差分が発生しました 🚨"
+          CHECK_SUMMARY="🚨 **Snapshotテストで差分が発生しました** 🚨\n\n"
       
           for file in artifacts/diffs/*.png; do
             BASENAME=$(basename "$file")
@@ -246,7 +247,7 @@ jobs:
             IMAGE_TABLE+="| -- | -- | -- |\n"
             IMAGE_TABLE+="| ![成功](data:image/png;base64,${SUCCESS_B64}) | ![差分](data:image/png;base64,${DIFF_B64}) | ![失敗](data:image/png;base64,${FAILED_B64}) |\n\n"
       
-            CHECK_SUMMARY=$(echo "$CHECK_SUMMARY" | jq --arg img_table "$IMAGE_TABLE" '.summary += $img_table')
+            CHECK_SUMMARY+="$IMAGE_TABLE"
           done
       
           # GitHub Checks を更新（結果を登録）
@@ -254,8 +255,8 @@ jobs:
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             "$GITHUB_API/$CHECK_ID" \
-            -d "$(jq -n --arg status "completed" --arg conclusion "failure" --argjson output "$CHECK_SUMMARY" \
-              '{status: $status, conclusion: $conclusion, output: $output}')"
+            -d "$(jq -n --arg status "completed" --arg conclusion "failure" --arg title "$CHECK_TITLE" --arg summary "$CHECK_SUMMARY" \
+              '{status: $status, conclusion: $conclusion, output: {title: $title, summary: $summary}}')"
       
           echo "::endgroup::"
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -140,25 +140,37 @@ jobs:
         run: |
           RELEASE_URL="https://github.com/${{ github.repository }}/releases/download/snapshot-diff"
       
-          # コメント本文を printf で改行付きで構築
-          COMMENT_BODY=$(printf "🚨 **Snapshotテストで差分が発生しています** 🚨\n\n")
-          COMMENT_BODY+=$(printf "以下に画像の差分を表示します。\n\n")
-          COMMENT_BODY+=$(printf "詳細な画像はこちらからダウンロードしてください。\n")
-          COMMENT_BODY+=$(printf "[📥 Artifactsをダウンロード](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)\n\n")
-      
+          # コメント本文を printf で改行付きで構築（printf は自動で改行を入れる）
+          COMMENT_BODY=$(cat <<EOF
+          🚨 **Snapshotテストで差分が発生しています** 🚨
+
+          以下に画像の差分を表示します。
+
+          詳細な画像はこちらからダウンロードしてください。
+          [📥 Artifactsをダウンロード](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)
+
+          EOF
+          )
+
           COUNT=1
           for file in artifacts/diffs/*.png; do
             IMAGE_URL="$RELEASE_URL/$(basename "$file")"
-      
-            COMMENT_BODY+=$(printf "### 画像${COUNT}\n\n")
-            COMMENT_BODY+=$(printf "| 既存 | 差分 | 新規 |\n")
-            COMMENT_BODY+=$(printf "| -- | -- | -- |\n")
-            COMMENT_BODY+=$(printf "| 空 | <img src=\"$IMAGE_URL\" width=\"300\"> | 空 |\n\n")
-      
+
+            COMMENT_BODY+=$(cat <<EOF
+
+          ### 画像${COUNT}
+
+          | 既存 | 差分 | 新規 |
+          | -- | -- | -- |
+          | 空 | <img src="${IMAGE_URL}" width="300"> | 空 |
+
+          EOF
+          )
+
             COUNT=$((COUNT + 1))
           done
-      
-          # JSONとして正しくエスケープし、GitHub API に送信
+
+          # JSONエスケープを適用し GitHub API に送信
           curl -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -95,52 +95,7 @@ jobs:
           name: snapshot-diffs
           path: artifacts/diffs/*.png
 
-      - name: Resize and encode images correctly
-        if: failure()
-        id: encode_diff_images
-        run: |
-          delimiter=$(openssl rand -hex 8)
-          mkdir -p ./artifacts/diffs_resized
-          if ls ./artifacts/diffs/*.png >/dev/null 2>&1; then
-            {
-              echo "ENCODED_IMAGES<<$delimiter"
-              for file in ./artifacts/diffs/*.png; do
-                resized="./artifacts/diffs_resized/$(basename "$file")"
-                convert "$file" -resize 500 "$resized"
-                encoded=$(base64 -i "$resized" | tr -d '\n')
-                echo "**$(basename "$file")**"
-                echo ""
-                echo "![Diff Image](data:image/png;base64,$encoded)"
-                echo ""
-              done
-              echo "$delimiter"
-            } >> "$GITHUB_OUTPUT"
-          else
-            echo "ENCODED_IMAGES=" >> "$GITHUB_OUTPUT"
-          fi
-
-#      - name: Comment on PR with snapshot diffs and Artifact link
-#        if: failure() && steps.encode_diff_images.outputs.ENCODED_IMAGES != ''
-#        uses: marocchino/sticky-pull-request-comment@v2
-#        with:
-#          token: ${{ secrets.MY_PAT }}
-#          message: |
-#            🚨 **Snapshotテストで差分が発生しています** 🚨
-#
-#            （縮小表示のため画像が小さいですが、差分は以下で確認できます）
-#
-#            ${{ steps.encode_diff_images.outputs.ENCODED_IMAGES }}
-#
-#            詳細な画像はこちらからダウンロードしてください。  
-#            [📥 Artifactsをダウンロード](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)
-#      - name: Upload diff images as Artifact
-#        if: failure()
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: snapshot-diffs
-#          path: artifacts/diffs/*.png
-
-      - name: Upload diff images to Issue comment and retrieve URLs
+      - name: Upload diff images to Issue and retrieve URLs
         if: failure()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -149,20 +104,25 @@ jobs:
       
           for file in artifacts/diffs/*.png; do
             echo "Uploading $file to GitHub Issue..."
-      
-            # 1️⃣ 画像をGitHub Issue コメントとして追加
+            
+            # 1️⃣ 画像をGitHub Issueコメントにアップロード
             RESPONSE=$(curl -s -X POST \
               -H "Authorization: token $GITHUB_TOKEN" \
               -H "Accept: application/vnd.github+json" \
               "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-              -d "{\"body\": \"![Uploading $(basename "$file")...](https://github.com)\"}")
+              -d "{\"body\": \"Uploading image: $(basename "$file")\"}")
       
-            # 2️⃣ IssueのコメントURLを取得
+            # 2️⃣ 投稿されたコメントのURLを取得
             COMMENT_URL=$(echo "$RESPONSE" | jq -r '.html_url')
       
-            # 3️⃣ 画像のURLを取得（GitHubが画像をホストするのを待つ）
-            sleep 5
-            IMAGE_URL=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "$COMMENT_URL" | grep -o 'https://user-images.githubusercontent.com[^)]*' | head -n1)
+            if [[ -z "$COMMENT_URL" || "$COMMENT_URL" == "null" ]]; then
+              echo "Failed to create issue comment for $file"
+              exit 1
+            fi
+      
+            # 3️⃣ コメント内の画像URLを取得
+            sleep 5 # GitHubが画像を処理するのを待つ
+            IMAGE_URL=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "$COMMENT_URL" | grep -o 'https://user-images.githubusercontent.com[^")]*' | head -n1)
       
             if [[ -z "$IMAGE_URL" || "$IMAGE_URL" == "null" ]]; then
               echo "Failed to retrieve uploaded image URL for $file"
@@ -172,7 +132,7 @@ jobs:
             COMMENT_BODY+="![Diff Image $(basename "$file")]($IMAGE_URL)\n\n"
           done
       
-          # 4️⃣ 画像URLをPRコメントに追加
+          # 4️⃣ PRに画像URLを投稿
           ESCAPED_BODY=$(echo "$COMMENT_BODY" | jq -Rs .)
       
           curl -X POST \

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -164,53 +164,35 @@ jobs:
 
           echo "Issue successfully created!"
 
-
-      - name: Upload success, failed, and diff images to GitHub Issue
-        if: failure()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 必要なツールをインストール
         run: |
-          echo "Creating GitHub Issue..."
-          
-          # Issue を作成
-          ISSUE_NUMBER=$(gh issue create --title "Snapshot Test Failures" --body "Snapshot tests failed. See the images below." --repo ${{ github.repository }} --label snapshot-test | awk '{print $NF}')
+          sudo apt-get update
+          sudo apt-get install -y jq curl
 
-          if [[ -z "$ISSUE_NUMBER" ]]; then
-            echo "Error: Issue creation failed"
-            exit 1
-          fi
+      - name: 画像をGitHub Issueにアップロード
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ISSUE_NUMBER=1  # 画像をアップロードするIssueの番号を指定
+          PR_NUMBER=${{ github.event.pull_request.number }}
 
-          ISSUE_URL="https://github.com/${{ github.repository }}/issues/${ISSUE_NUMBER}"
-          echo "Issue created: $ISSUE_URL"
-
-          # 画像を imgur にアップロード（GitHub API では直接アップロード不可のため、外部サービスを利用）
-          upload_image() {
-            local image_path="$1"
-            local image_url=$(curl -s -F "image=@${image_path}" "https://api.imgur.com/3/upload" -H "Authorization: Client-ID YOUR_IMGUR_CLIENT_ID" | jq -r '.data.link')
-            echo "$image_url"
-          }
-
-          # Markdown の画像リストを作成
-          echo "## Snapshot Test Failures" > snapshot_summary.md
-          echo "- Issue URL: $ISSUE_URL" >> snapshot_summary.md
+          # 画像アップロード用のコメントを作成
+          echo "Uploading images to issue #$ISSUE_NUMBER..."
 
           for file in artifacts/success/*.png; do
-            IMAGE_URL=$(upload_image "$file")
+            IMAGE_URL=$(gh issue comment $ISSUE_NUMBER --body "![]($(gh issue upload $ISSUE_NUMBER $file))")
             echo "✅ Success: ![]($IMAGE_URL)" >> snapshot_summary.md
           done
 
           for file in artifacts/failed/*.png; do
-            IMAGE_URL=$(upload_image "$file")
+            IMAGE_URL=$(gh issue comment $ISSUE_NUMBER --body "![]($(gh issue upload $ISSUE_NUMBER $file))")
             echo "❌ Failed: ![]($IMAGE_URL)" >> snapshot_summary.md
           done
 
           for file in artifacts/diffs/*.png; do
-            IMAGE_URL=$(upload_image "$file")
+            IMAGE_URL=$(gh issue comment $ISSUE_NUMBER --body "![]($(gh issue upload $ISSUE_NUMBER $file))")
             echo "🔄 Diff: ![]($IMAGE_URL)" >> snapshot_summary.md
           done
-
-          # GitHub Issue にコメントとして画像を追加
-          gh issue comment "$ISSUE_NUMBER" --body "$(cat snapshot_summary.md)" --repo ${{ github.repository }}
 
 #      - name: Upload success, failed, and diff images to GitHub Release
 #        if: failure()

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -148,13 +148,15 @@ jobs:
           COMMENT_BODY="🚨 **Snapshotテストで差分が発生しています** 🚨\n\n"
 
           for file in artifacts/diffs/*.png; do
-            URL=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            RESPONSE=$(curl -s -X POST \
+              -H "Authorization: token $GITHUB_TOKEN" \
               -H "Accept: application/vnd.github+json" \
-              -X POST "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-              -F "body=@$file;type=$(file -b --mime-type "$file")" \
-              | jq -r '.body' | grep -Eo 'https://user-images.githubusercontent.com[^)]+' | head -n1)
-      
-            COMMENT_BODY+="![Diff Image $(basename "$file")]($COMMENT_BODY)\n\n"
+              "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+              -d "{\"body\": \"![Diff Image $(basename \"$file\")]()\"}")
+
+            URL=$(echo "$RESPONSE" | jq -r '.body' | grep -Eo 'https://user-images.githubusercontent.com[^)]+' | head -n1)
+
+            COMMENT_BODY+="![Diff Image $(basename \"$file\")]($URL)\n\n"
           done
 
           curl -X POST \

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -117,6 +117,7 @@ jobs:
           path: artifacts/failed/*.png
 
       - name: 比較用ブランチ作成 & 画像をコミット
+        if: failure()
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
@@ -127,6 +128,7 @@ jobs:
           git push origin comparison-screenshots --force
 
       - name: コメント本文を生成
+        if: failure()
         id: generate_comment
         shell: bash
         run: |
@@ -159,6 +161,7 @@ jobs:
                     echo "::set-output name=body::$(cat comment.md)"
 
       - name: PR にコメント投稿
+        if: failure()
         uses: peter-evans/create-or-update-comment@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -133,34 +133,35 @@ jobs:
 #
 #            詳細な画像はこちらからダウンロードしてください。  
 #            [📥 Artifactsをダウンロード](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)
-      - name: Upload images to PR comments and get image URLs
+      - name: Upload diff images as Artifact
         if: failure()
-        id: upload_images
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapshot-diffs
+          path: artifacts/diffs/*.png
+
+      - name: Upload diff images to Issue comment
+        if: failure()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          IMAGE_URLS=""
+          COMMENT_BODY="🚨 **Snapshotテストで差分が発生しています** 🚨\n\n"
+
           for file in artifacts/diffs/*.png; do
-            upload_response=$(curl -X POST \
-              -H "Authorization: token $GITHUB_TOKEN" \
+            URL=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
               -H "Accept: application/vnd.github+json" \
-              -H "Content-Type: $(file -b --mime-type "$file")" \
-              --data-binary @"$file" \
-              "https://uploads.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-              | jq -r '.body' \
-              | grep -o 'https://user-images.githubusercontent.com[^)]*')
+              -X POST "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+              -F "body=@$file;type=$(file -b --mime-type "$file")" \
+              | jq -r '.body' | grep -Eo 'https://user-images.githubusercontent.com[^)]+' | head -n1)
       
-            IMAGE_MARKDOWN="${IMAGE_MARKDOWN}![$(basename "$file")]($upload_response)\n\n"
+            COMMENT_BODY+="![Diff Image $(basename "$file")]($COMMENT_BODY)\n\n"
           done
 
-      - name: Comment on PR with uploaded images
-        if: failure()
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          message: |
-            🚨 **Snapshotテストで差分が発生しています** 🚨
-            ${{ env.IMAGE_MARKDOWN }}
+          curl -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            -d "{\"body\": \"$COMMENT_BODY\"}"
 
       # Issueにあげて公開URLを取得すると良さそう
       - name: Cache VRT snapshots

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -95,51 +95,62 @@ jobs:
           name: snapshot-diffs
           path: artifacts/diffs/*.png
 
-      - name: Upload diff images to Issue and retrieve URLs
+      - name: Create GitHub Release (if not exists)
+        if: failure()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RELEASE_NAME="snapshot-diff-release"
+          EXISTING_RELEASE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/releases" | jq -r ".[] | select(.name==\"$RELEASE_NAME\") | .id")
+      
+          if [ -z "$EXISTING_RELEASE" ]; then
+            echo "Creating new release..."
+            RESPONSE=$(curl -s -X POST \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github.v3+json" \
+              "https://api.github.com/repos/${{ github.repository }}/releases" \
+              -d "{\"tag_name\": \"snapshot-diff\", \"name\": \"$RELEASE_NAME\", \"body\": \"Snapshot diff images\"}")
+            RELEASE_ID=$(echo "$RESPONSE" | jq -r '.id')
+          else
+            echo "Release already exists. Using ID: $EXISTING_RELEASE"
+            RELEASE_ID=$EXISTING_RELEASE
+          fi
+      
+          echo "RELEASE_ID=$RELEASE_ID" >> $GITHUB_ENV
+
+      - name: Upload diff images to GitHub Release
+        if: failure()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for file in artifacts/diffs/*.png; do
+            echo "Uploading $file to GitHub Release..."
+            curl -s -X POST \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Content-Type: application/octet-stream" \
+              "https://uploads.github.com/repos/${{ github.repository }}/releases/$RELEASE_ID/assets?name=$(basename "$file")" \
+              --data-binary @$file
+          done
+
+      - name: Comment on PR with snapshot diffs from Release
         if: failure()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           COMMENT_BODY="🚨 **Snapshotテストで差分が発生しています** 🚨\n\n"
+          RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/snapshot-diff"
       
           for file in artifacts/diffs/*.png; do
-            echo "Uploading $file to GitHub Issue..."
-            
-            # 1️⃣ 画像をGitHub Issueコメントにアップロード
-            RESPONSE=$(curl -s -X POST \
-              -H "Authorization: token $GITHUB_TOKEN" \
-              -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-              -d "{\"body\": \"Uploading image: $(basename "$file")\"}")
-      
-            # 2️⃣ 投稿されたコメントのURLを取得
-            COMMENT_URL=$(echo "$RESPONSE" | jq -r '.html_url')
-      
-            if [[ -z "$COMMENT_URL" || "$COMMENT_URL" == "null" ]]; then
-              echo "Failed to create issue comment for $file"
-              exit 1
-            fi
-      
-            # 3️⃣ コメント内の画像URLを取得
-            sleep 5 # GitHubが画像を処理するのを待つ
-            IMAGE_URL=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "$COMMENT_URL" | grep -o 'https://user-images.githubusercontent.com[^")]*' | head -n1)
-      
-            if [[ -z "$IMAGE_URL" || "$IMAGE_URL" == "null" ]]; then
-              echo "Failed to retrieve uploaded image URL for $file"
-              exit 1
-            fi
-      
+            IMAGE_URL="$RELEASE_URL/$(basename "$file")"
             COMMENT_BODY+="![Diff Image $(basename "$file")]($IMAGE_URL)\n\n"
           done
-      
-          # 4️⃣ PRに画像URLを投稿
-          ESCAPED_BODY=$(echo "$COMMENT_BODY" | jq -Rs .)
       
           curl -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-            -d "{\"body\": $ESCAPED_BODY}"
+            -d "{\"body\": \"$COMMENT_BODY\"}"
 
       # Issueにあげて公開URLを取得すると良さそう
       - name: Cache VRT snapshots

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -151,7 +151,7 @@ jobs:
             RESPONSE=$(curl -s -X POST \
               -H "Authorization: token $GITHUB_TOKEN" \
               -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+              "https://api.github.com/repos/${{ github.repository }}/issues/2/comments" \
               -d "{\"body\": \"![Diff Image $(basename \"$file\")]()\"}")
 
             URL=$(echo "$RESPONSE" | jq -r '.body' | grep -Eo 'https://user-images.githubusercontent.com[^)]+' | head -n1)
@@ -162,7 +162,7 @@ jobs:
           curl -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/2/comments" \
             -d "{\"body\": \"$COMMENT_BODY\"}"
 
       # Issueにあげて公開URLを取得すると良さそう

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -140,42 +140,81 @@ jobs:
       
           echo "RELEASE_ID=$RELEASE_ID" >> $GITHUB_ENV
 
-      - name: Upload success, failed, and diff images to GitHub Release
+      - name: Upload success, failed, and diff images to GitHub Issue
         if: failure()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          UPLOAD_URL="https://uploads.github.com/repos/${{ github.repository }}/releases/$RELEASE_ID/assets"
-      
-          # 成功画像のアップロード
+          # GitHub Issue を作成
+          ISSUE_URL=$(gh issue create --title "Snapshot Test Failures" --body "Snapshot tests failed. See the images below." --repo ${{ github.repository }} --label snapshot-test --json url | jq -r '.url')
+          
+          echo "Issue created: $ISSUE_URL"
+
+          # 画像を imgur にアップロード（GitHub API では直接アップロード不可のため、外部サービスを利用）
+          upload_image() {
+            local image_path="$1"
+            local image_url=$(curl -s -F "image=@${image_path}" "https://api.imgur.com/3/upload" -H "Authorization: Client-ID YOUR_IMGUR_CLIENT_ID" | jq -r '.data.link')
+            echo "$image_url"
+          }
+
+          # Markdown の画像リストを作成
+          echo "## Snapshot Test Failures" > snapshot_summary.md
+          echo "- Issue URL: $ISSUE_URL" >> snapshot_summary.md
+
           for file in artifacts/success/*.png; do
-            echo "Uploading success image: $file"
-            curl -s -X POST \
-              -H "Authorization: token $GITHUB_TOKEN" \
-              -H "Content-Type: application/octet-stream" \
-              "$UPLOAD_URL?name=success_$(basename "$file")" \
-              --data-binary @"$file"
+            IMAGE_URL=$(upload_image "$file")
+            echo "✅ Success: ![]($IMAGE_URL)" >> snapshot_summary.md
           done
-      
-          # 失敗画像のアップロード
+
           for file in artifacts/failed/*.png; do
-            echo "Uploading failed image: $file"
-            curl -s -X POST \
-              -H "Authorization: token $GITHUB_TOKEN" \
-              -H "Content-Type: application/octet-stream" \
-              "$UPLOAD_URL?name=failed_$(basename "$file")" \
-              --data-binary @"$file"
+            IMAGE_URL=$(upload_image "$file")
+            echo "❌ Failed: ![]($IMAGE_URL)" >> snapshot_summary.md
           done
-      
-          # 差分画像のアップロード
+
           for file in artifacts/diffs/*.png; do
-            echo "Uploading diff image: $file"
-            curl -s -X POST \
-              -H "Authorization: token $GITHUB_TOKEN" \
-              -H "Content-Type: application/octet-stream" \
-              "$UPLOAD_URL?name=$(basename "$file")" \
-              --data-binary @"$file"
+            IMAGE_URL=$(upload_image "$file")
+            echo "🔄 Diff: ![]($IMAGE_URL)" >> snapshot_summary.md
           done
+
+          # GitHub Issue にコメントとして画像を追加
+          gh issue comment "$ISSUE_URL" --body "$(cat snapshot_summary.md)" --repo ${{ github.repository }}
+
+#      - name: Upload success, failed, and diff images to GitHub Release
+#        if: failure()
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        run: |
+#          UPLOAD_URL="https://uploads.github.com/repos/${{ github.repository }}/releases/$RELEASE_ID/assets"
+#      
+#          # 成功画像のアップロード
+#          for file in artifacts/success/*.png; do
+#            echo "Uploading success image: $file"
+#            curl -s -X POST \
+#              -H "Authorization: token $GITHUB_TOKEN" \
+#              -H "Content-Type: application/octet-stream" \
+#              "$UPLOAD_URL?name=success_$(basename "$file")" \
+#              --data-binary @"$file"
+#          done
+#      
+#          # 失敗画像のアップロード
+#          for file in artifacts/failed/*.png; do
+#            echo "Uploading failed image: $file"
+#            curl -s -X POST \
+#              -H "Authorization: token $GITHUB_TOKEN" \
+#              -H "Content-Type: application/octet-stream" \
+#              "$UPLOAD_URL?name=failed_$(basename "$file")" \
+#              --data-binary @"$file"
+#          done
+#      
+#          # 差分画像のアップロード
+#          for file in artifacts/diffs/*.png; do
+#            echo "Uploading diff image: $file"
+#            curl -s -X POST \
+#              -H "Authorization: token $GITHUB_TOKEN" \
+#              -H "Content-Type: application/octet-stream" \
+#              "$UPLOAD_URL?name=$(basename "$file")" \
+#              --data-binary @"$file"
+#          done
 
 #      - name: Comment on PR with structured snapshot diffs from Release
 #        if: failure()
@@ -221,57 +260,6 @@ jobs:
 #                -H "Accept: application/vnd.github+json" \
 #                "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
 #                -d "$(jq -Rs --arg body "$COMMENT_BODY" '{body: $body}' <<< "")"
-
-      - name: Report Snapshot Diffs via GitHub Checks
-        if: failure()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "::group::Processing snapshot images for GitHub Checks"
-      
-          CHECK_NAME="Snapshot Diff Report"
-          GITHUB_API="https://api.github.com/repos/${{ github.repository }}/check-runs"
-      
-          # GitHub Checks の開始
-          CHECK_RUN=$(curl -s -X POST \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "$GITHUB_API" \
-            -d "$(jq -n --arg name "$CHECK_NAME" --arg head_sha "${{ github.event.pull_request.head.sha }}" \
-              '{name: $name, head_sha: $head_sha, status: "in_progress"}')")
-      
-          CHECK_ID=$(echo "$CHECK_RUN" | jq -r '.id')
-      
-          # GitHub Actions Artifacts の URL を取得
-          ARTIFACTS_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts"
-      
-          CHECK_TITLE="🚨 Snapshotテストで差分が発生しました 🚨"
-          CHECK_SUMMARY="🚨 **Snapshotテストで差分が発生しました** 🚨\n\n"
-          CHECK_SUMMARY+="[📥 画像をダウンロード（Artifacts）]($ARTIFACTS_URL)\n\n"
-      
-          # 画像を GitHub Checks に埋め込む（Artifacts のダウンロードリンクを表示）
-          CHECK_SUMMARY+="| 既存（成功時） | 差分 | 新規（失敗時） |\n"
-          CHECK_SUMMARY+="| -- | -- | -- |\n"
-      
-          for file in artifacts/diffs/*.png; do
-            BASENAME=$(basename "$file")
-            FILENAME=${BASENAME#diff_}
-      
-            CHECK_SUMMARY+="| ![成功]($ARTIFACTS_URL) | ![差分]($ARTIFACTS_URL) | ![失敗]($ARTIFACTS_URL) |\n"
-          done
-      
-          # JSONエスケープ
-          ESCAPED_SUMMARY=$(jq -Rs . <<< "$CHECK_SUMMARY")
-      
-          # GitHub Checks を更新（結果を登録）
-          curl -s -X PATCH \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "$GITHUB_API/$CHECK_ID" \
-            -d "$(jq -n --arg status "completed" --arg conclusion "failure" --arg title "$CHECK_TITLE" --arg summary "$ESCAPED_SUMMARY" \
-              '{status: $status, conclusion: $conclusion, output: {title: $title, summary: $summary}}')"
-      
-          echo "::endgroup::"
 
       # Issueにあげて公開URLを取得すると良さそう
       - name: Cache VRT snapshots

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -140,7 +140,7 @@ jobs:
 #          name: snapshot-diffs
 #          path: artifacts/diffs/*.png
 
-      - name: Upload diff images via Markdown API and comment on PR
+      - name: Upload diff images to Issue comment and retrieve URLs
         if: failure()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -148,26 +148,31 @@ jobs:
           COMMENT_BODY="🚨 **Snapshotテストで差分が発生しています** 🚨\n\n"
       
           for file in artifacts/diffs/*.png; do
-            echo "Uploading $file to GitHub via Markdown API..."
-            
-            # 1️⃣ GitHubのMarkdown APIを使って画像をアップロード
+            echo "Uploading $file to GitHub Issue..."
+      
+            # 1️⃣ 画像をGitHub Issue コメントとして追加
             RESPONSE=$(curl -s -X POST \
               -H "Authorization: token $GITHUB_TOKEN" \
-              -H "Accept: application/vnd.github.v3+json" \
-              -d "{\"text\":\"![Uploading $file...](https://github.com)\"}" \
-              "https://api.github.com/markdown")
-            
-            IMAGE_URL=$(echo "$RESPONSE" | grep -o 'https://user-images.githubusercontent.com[^)]*' | head -n1)
-            
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+              -d "{\"body\": \"![Uploading $(basename "$file")...](https://github.com)\"}")
+      
+            # 2️⃣ IssueのコメントURLを取得
+            COMMENT_URL=$(echo "$RESPONSE" | jq -r '.html_url')
+      
+            # 3️⃣ 画像のURLを取得（GitHubが画像をホストするのを待つ）
+            sleep 5
+            IMAGE_URL=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "$COMMENT_URL" | grep -o 'https://user-images.githubusercontent.com[^)]*' | head -n1)
+      
             if [[ -z "$IMAGE_URL" || "$IMAGE_URL" == "null" ]]; then
-              echo "Failed to upload $file"
+              echo "Failed to retrieve uploaded image URL for $file"
               exit 1
             fi
-            
+      
             COMMENT_BODY+="![Diff Image $(basename "$file")]($IMAGE_URL)\n\n"
           done
       
-          # 2️⃣ PRにコメントを投稿
+          # 4️⃣ 画像URLをPRコメントに追加
           ESCAPED_BODY=$(echo "$COMMENT_BODY" | jq -Rs .)
       
           curl -X POST \

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -158,9 +158,9 @@ jobs:
           rows=""
           for fname in "${files[@]}"; do
             rows="${rows}"$'    <tr>\n'
-            rows="${rows}"$'      <td>'${fname}'<br><img src="'${BASE_URL}'/success/'${fname}'" width="300"></td>\n'
-            rows="${rows}"$'      <td>'${fname}'<br><img src="'${BASE_URL}'/diffs/'${fname}'" width="300"></td>\n'
-            rows="${rows}"$'      <td>'${fname}'<br><img src="'${BASE_URL}'/failed/'${fname}'" width="300"></td>\n'
+            rows="${rows}"$'      <td>'${fname}'<br><img src="'${BASE_URL}'/success/'${fname}'" width="300"></td>'
+            rows="${rows}"$'      <td>'${fname}'<br><img src="'${BASE_URL}'/diffs/'${fname}'" width="300"></td>'
+            rows="${rows}"$'      <td>'${fname}'<br><img src="'${BASE_URL}'/failed/'${fname}'" width="300"></td>'
             rows="${rows}"$'    </tr>\n'
           done
           if [ -z "$rows" ]; then

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -116,31 +116,32 @@ jobs:
           name: snapshot-failed
           path: artifacts/failed/*.png
 
-      - name: Create GitHub Release (if not exists)
-        if: failure()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          RELEASE_NAME="snapshot-diff-release"
-          EXISTING_RELEASE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-            "https://api.github.com/repos/${{ github.repository }}/releases" | jq -r ".[] | select(.name==\"$RELEASE_NAME\") | .id")
-      
-          if [ -z "$EXISTING_RELEASE" ]; then
-            echo "Creating new release..."
-            RESPONSE=$(curl -s -X POST \
-              -H "Authorization: token $GITHUB_TOKEN" \
-              -H "Accept: application/vnd.github.v3+json" \
-              "https://api.github.com/repos/${{ github.repository }}/releases" \
-              -d "{\"tag_name\": \"snapshot-diff\", \"name\": \"$RELEASE_NAME\", \"body\": \"Snapshot diff images\"}")
-            RELEASE_ID=$(echo "$RESPONSE" | jq -r '.id')
-          else
-            echo "Release already exists. Using ID: $EXISTING_RELEASE"
-            RELEASE_ID=$EXISTING_RELEASE
-          fi
-      
-          echo "RELEASE_ID=$RELEASE_ID" >> $GITHUB_ENV
+#      - name: Create GitHub Release (if not exists)
+#        if: failure()
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        run: |
+#          RELEASE_NAME="snapshot-diff-release"
+#          EXISTING_RELEASE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+#            "https://api.github.com/repos/${{ github.repository }}/releases" | jq -r ".[] | select(.name==\"$RELEASE_NAME\") | .id")
+#      
+#          if [ -z "$EXISTING_RELEASE" ]; then
+#            echo "Creating new release..."
+#            RESPONSE=$(curl -s -X POST \
+#              -H "Authorization: token $GITHUB_TOKEN" \
+#              -H "Accept: application/vnd.github.v3+json" \
+#              "https://api.github.com/repos/${{ github.repository }}/releases" \
+#              -d "{\"tag_name\": \"snapshot-diff\", \"name\": \"$RELEASE_NAME\", \"body\": \"Snapshot diff images\"}")
+#            RELEASE_ID=$(echo "$RESPONSE" | jq -r '.id')
+#          else
+#            echo "Release already exists. Using ID: $EXISTING_RELEASE"
+#            RELEASE_ID=$EXISTING_RELEASE
+#          fi
+#      
+#          echo "RELEASE_ID=$RELEASE_ID" >> $GITHUB_ENV
 
       - name: Create GitHub Issue for Snapshot Failures
+        if: failure()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -102,6 +102,20 @@ jobs:
           name: snapshot-diffs
           path: artifacts/diffs/*.png
 
+      - name: Upload success images as Artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapshot-success
+          path: artifacts/success/*.png
+
+      - name: Upload failed images as Artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapshot-failed
+          path: artifacts/failed/*.png
+
       - name: Create GitHub Release (if not exists)
         if: failure()
         env:
@@ -228,64 +242,34 @@ jobs:
       
           CHECK_ID=$(echo "$CHECK_RUN" | jq -r '.id')
       
-          # コメント用変数（JSONエスケープ対応）
-          CHECK_TITLE="🚨 Snapshotテストで差分が発生しました 🚨"
-          CHECK_SUMMARY="🚨 **Snapshotテストで差分が発生しました** 🚨\n\n以下に詳細な画像の差分を表示します。\n\n"
+          # GitHub Actions Artifacts の URL を取得
+          ARTIFACTS_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts"
       
-          # GitHub Checks の `annotations`
-          ANNOTATIONS=()
+          CHECK_TITLE="🚨 Snapshotテストで差分が発生しました 🚨"
+          CHECK_SUMMARY="🚨 **Snapshotテストで差分が発生しました** 🚨\n\n"
+          CHECK_SUMMARY+="[📥 画像をダウンロード（Artifacts）]($ARTIFACTS_URL)\n\n"
+      
+          # 画像を GitHub Checks に埋め込む（Artifacts のダウンロードリンクを表示）
+          CHECK_SUMMARY+="| 既存（成功時） | 差分 | 新規（失敗時） |\n"
+          CHECK_SUMMARY+="| -- | -- | -- |\n"
       
           for file in artifacts/diffs/*.png; do
             BASENAME=$(basename "$file")
             FILENAME=${BASENAME#diff_}
       
-            # macOS の `base64` は `-w 0` ではなく `tr -d '\n'` を使う
-            if [ -f "$file" ]; then
-              DIFF_B64=$(base64 "$file" | tr -d '\n')
-            else
-              DIFF_B64=""
-            fi
-      
-            if [ -f "artifacts/success/$FILENAME" ]; then
-              SUCCESS_B64=$(base64 "artifacts/success/$FILENAME" | tr -d '\n')
-            else
-              SUCCESS_B64=""
-            fi
-      
-            if [ -f "artifacts/failed/$FILENAME" ]; then
-              FAILED_B64=$(base64 "artifacts/failed/$FILENAME" | tr -d '\n')
-            else
-              FAILED_B64=""
-            fi
-      
-            # 画像テーブル
-            IMAGE_TABLE="### ${FILENAME}\n\n"
-            IMAGE_TABLE+="| 既存（成功時） | 差分 | 新規（失敗時） |\n"
-            IMAGE_TABLE+="| -- | -- | -- |\n"
-            IMAGE_TABLE+="| ![成功](data:image/png;base64,${SUCCESS_B64}) | ![差分](data:image/png;base64,${DIFF_B64}) | ![失敗](data:image/png;base64,${FAILED_B64}) |\n\n"
-      
-            CHECK_SUMMARY+="$IMAGE_TABLE"
-      
-            # Annotations に追加
-            ANNOTATIONS+=("$(jq -n \
-              --arg path "$FILENAME" \
-              --arg message "Snapshot difference found: $FILENAME" \
-              --arg annotation_level "warning" \
-              --arg title "Snapshot Diff: $FILENAME" \
-              '{path: $path, message: $message, annotation_level: $annotation_level, title: $title}')")
+            CHECK_SUMMARY+="| ![成功]($ARTIFACTS_URL) | ![差分]($ARTIFACTS_URL) | ![失敗]($ARTIFACTS_URL) |\n"
           done
       
-          # JSONエスケープ（エラー回避）
+          # JSONエスケープ
           ESCAPED_SUMMARY=$(jq -Rs . <<< "$CHECK_SUMMARY")
       
-          # GitHub Checks を更新（Annotations を含める）
+          # GitHub Checks を更新（結果を登録）
           curl -s -X PATCH \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             "$GITHUB_API/$CHECK_ID" \
             -d "$(jq -n --arg status "completed" --arg conclusion "failure" --arg title "$CHECK_TITLE" --arg summary "$ESCAPED_SUMMARY" \
-              --argjson annotations "[${ANNOTATIONS[*]}]" \
-              '{status: $status, conclusion: $conclusion, output: {title: $title, summary: $summary, annotations: $annotations}}')"
+              '{status: $status, conclusion: $conclusion, output: {title: $title, summary: $summary}}')"
       
           echo "::endgroup::"
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -127,17 +127,6 @@ jobs:
           git commit -m "Add snapshot test screenshots for comparison"
           git push origin comparison-screenshots --force
 
-      - name: 比較用ブランチ作成 & 画像をコミット
-        if: ${{ failure() }}
-        run: |
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "actions@github.com"
-          git checkout --orphan comparison-screenshots
-          git reset --hard
-          git add artifacts
-          git commit -m "Add snapshot test screenshots for comparison"
-          git push origin comparison-screenshots --force
-
       - name: コメント本文を生成
         if: ${{ failure() }}
         id: generate_comment

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -137,9 +137,9 @@ jobs:
           BRANCH=comparison-screenshots
           BASE_URL="https://raw.githubusercontent.com/${REPO}/${BRANCH}/artifacts"
           
-          # rows 変数に各画像の行を作成（改行を入れるため $'…\n' を使用）
+          # diff 画像を基準にテーブル行を生成
           rows=""
-          for file in artifacts/success/*.png; do
+          for file in artifacts/diffs/*.png; do
             filename=$(basename "$file")
             rows="${rows}"$'    <tr>\n'
             rows="${rows}"$'      <td><img src="'${BASE_URL}'/success/'${filename}'" width="300"></td>\n'
@@ -151,7 +151,6 @@ jobs:
             rows=$'    <tr><td colspan="3">No images found</td></tr>\n'
           fi
           
-          # ヒアドキュメントでテーブル全体を生成
           comment=$(cat <<EOF
           <table>
             <thead>
@@ -167,7 +166,6 @@ jobs:
           EOF
           )
           echo "$comment" > comment.md
-          # 新しい方法で出力を設定
           {
             echo "body<<EOF"
             cat comment.md

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -133,79 +133,38 @@ jobs:
               --data-binary @$file
           done
 
-#      - name: Comment on PR with snapshot diffs from Release
-#        if: failure()
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        run: |
-#          COMMENT_BODY="🚨 **Snapshotテストで差分が発生しています** 🚨\n\n"
-#          RELEASE_URL="https://github.com/${{ github.repository }}/releases/download/snapshot-diff"
-#      
-#          for file in artifacts/diffs/*.png; do
-#            IMAGE_URL="$RELEASE_URL/$(basename "$file")"
-#            COMMENT_BODY+="<img src=\"$IMAGE_URL\" width=\"300\">\n\n"
-#          done
-#      
-#          # JSONとして正しくエスケープする
-#          ESCAPED_BODY=$(echo "$COMMENT_BODY" | jq -Rs .)
-#      
-#          curl -X POST \
-#            -H "Authorization: token $GITHUB_TOKEN" \
-#            -H "Accept: application/vnd.github+json" \
-#            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-#            -d "{\"body\": $ESCAPED_BODY}"
-
-      - name: Generate Markdown table for PR comment
+      - name: Comment on PR with structured snapshot diffs from Release
         if: failure()
-        id: generate_markdown
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Releasesに保存された画像のURLベース
+          COMMENT_BODY="🚨 **Snapshotテストで差分が発生しています** 🚨\n\n"
+          COMMENT_BODY+="以下に画像の差分を表示します。\n\n"
+          COMMENT_BODY+="詳細な画像はこちらからダウンロードしてください。\n"
+          COMMENT_BODY+="[📥 Artifactsをダウンロード](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)\n\n"
+      
           RELEASE_URL="https://github.com/${{ github.repository }}/releases/download/snapshot-diff"
           
-          # Cacheから取得する画像（既存の成功スナップショット）
-          EXISTING_DIR="./citest02/Snapshots/__Snapshots__/SnapshotFilePath"
+          COUNT=1
+          for file in artifacts/diffs/*.png; do
+            IMAGE_URL="$RELEASE_URL/$(basename "$file")"
+            
+            COMMENT_BODY+="### 画像${COUNT}\n\n"
+            COMMENT_BODY+="| 既存 | 差分 | 新規 |\n"
+            COMMENT_BODY+="| -- | -- | -- |\n"
+            COMMENT_BODY+="| 空 | <img src=\"$IMAGE_URL\" width=\"300\"> | 空 |\n\n"
       
-          # 差分画像のあるディレクトリ
-          DIFF_DIR="./artifacts/diffs"
-      
-          # PRにコメントするMarkdownを生成
-          echo "COMMENT_MARKDOWN<<EOF" >> $GITHUB_ENV
-          echo "### 画像名" >> $GITHUB_ENV
-          echo "" >> $GITHUB_ENV
-          echo "| 既存 | 差分 | 新規 |" >> $GITHUB_ENV
-          echo "| -- | -- | -- |" >> $GITHUB_ENV
-      
-          for diff_file in "$DIFF_DIR"/*.png; do
-            filename=$(basename "$diff_file")
-      
-            # 既存画像のURL
-            existing_url="$RELEASE_URL/$filename"
-      
-            # 差分画像のURL（Artifactsにアップロードしたものを使用）
-            diff_url="$RELEASE_URL/$filename"
-      
-            # 新規画像（今は未アップロードなので空白）
-            new_url="(未アップロード)"
-      
-            echo "| <img src=\"$existing_url\" width=\"300\"> | <img src=\"$diff_url\" width=\"300\"> | $new_url |" >> $GITHUB_ENV
+            COUNT=$((COUNT + 1))
           done
       
-          echo "EOF" >> $GITHUB_ENV
-
-      - name: Comment on PR with formatted snapshot diffs
-        if: failure()
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          token: ${{ secrets.MY_PAT }}
-          message: |
-            🚨 **Snapshotテストで差分が発生しています** 🚨
+          # JSONとして正しくエスケープする
+          ESCAPED_BODY=$(echo "$COMMENT_BODY" | jq -Rs .)
       
-            ${{ env.COMMENT_MARKDOWN }}
-      
-            ---
-            🔗 **詳細画像はこちらから**  
-            [📥 Artifactsをダウンロード](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)
-
+          curl -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            -d "{\"body\": $ESCAPED_BODY}"
 
       # Issueにあげて公開URLを取得すると良さそう
       - name: Cache VRT snapshots

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -222,17 +222,14 @@ jobs:
           CHECK_RUN=$(curl -s -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
-            $GITHUB_API \
-            -d "{
-              \"name\": \"$CHECK_NAME\",
-              \"head_sha\": \"${{ github.event.pull_request.head.sha }}\",
-              \"status\": \"in_progress\"
-            }")
+            "$GITHUB_API" \
+            -d "$(jq -n --arg name "$CHECK_NAME" --arg head_sha "${{ github.event.pull_request.head.sha }}" \
+              '{name: $name, head_sha: $head_sha, status: "in_progress"}')")
       
           CHECK_ID=$(echo "$CHECK_RUN" | jq -r '.id')
       
-          # コメント用変数
-          CHECK_SUMMARY="🚨 **Snapshotテストで差分が発生しました** 🚨\n\n"
+          # コメント用変数（JSONエスケープ対応）
+          CHECK_SUMMARY=$(jq -n --arg text "🚨 **Snapshotテストで差分が発生しました** 🚨\n\n" '{summary: $text}')
       
           for file in artifacts/diffs/*.png; do
             BASENAME=$(basename "$file")
@@ -243,11 +240,13 @@ jobs:
             SUCCESS_B64=$(base64 "artifacts/success/$FILENAME" | tr -d '\n')
             FAILED_B64=$(base64 "artifacts/failed/$FILENAME" | tr -d '\n')
       
-            # GitHub Checks に表示するMarkdownテーブルを作成
-            CHECK_SUMMARY+="### ${FILENAME}\n\n"
-            CHECK_SUMMARY+="| 既存（成功時） | 差分 | 新規（失敗時） |\n"
-            CHECK_SUMMARY+="| -- | -- | -- |\n"
-            CHECK_SUMMARY+="| <img src=\"data:image/png;base64,${SUCCESS_B64}\" width=\"300\"> | <img src=\"data:image/png;base64,${DIFF_B64}\" width=\"300\"> | <img       src=\"data:image/png;base64,${FAILED_B64}\" width=\"300\"> |\n\n"
+            # GitHub Checks に表示するMarkdownテーブルを作成（JSON対応）
+            IMAGE_TABLE="### ${FILENAME}\n\n"
+            IMAGE_TABLE+="| 既存（成功時） | 差分 | 新規（失敗時） |\n"
+            IMAGE_TABLE+="| -- | -- | -- |\n"
+            IMAGE_TABLE+="| ![成功](data:image/png;base64,${SUCCESS_B64}) | ![差分](data:image/png;base64,${DIFF_B64}) | ![失敗](data:image/png;base64,${FAILED_B64}) |\n\n"
+      
+            CHECK_SUMMARY=$(echo "$CHECK_SUMMARY" | jq --arg img_table "$IMAGE_TABLE" '.summary += $img_table')
           done
       
           # GitHub Checks を更新（結果を登録）
@@ -255,14 +254,8 @@ jobs:
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             "$GITHUB_API/$CHECK_ID" \
-            -d "{
-              \"status\": \"completed\",
-              \"conclusion\": \"failure\",
-              \"output\": {
-                \"title\": \"$CHECK_NAME\",
-                \"summary\": \"$CHECK_SUMMARY\"
-              }
-            }"
+            -d "$(jq -n --arg status "completed" --arg conclusion "failure" --argjson output "$CHECK_SUMMARY" \
+              '{status: $status, conclusion: $conclusion, output: $output}')"
       
           echo "::endgroup::"
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -117,57 +117,48 @@ jobs:
           path: artifacts/failed/*.png
 
       - name: 比較用ブランチ作成 & 画像をコミット
-        if: failure()
         run: |
-          # Git のユーザー設定（必要に応じて）
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
-          # 新しい orphan ブランチを作成
           git checkout --orphan comparison-screenshots
           git reset --hard
-          # artifacts ディレクトリを追加
           git add artifacts
           git commit -m "Add snapshot test screenshots for comparison"
-          # ブランチを強制プッシュ
           git push origin comparison-screenshots --force
 
       - name: コメント本文を生成
-        if: failure()
         id: generate_comment
         shell: bash
         run: |
-          # リポジトリ情報と新しいブランチ名から画像 URL のベースを生成
           REPO=${GITHUB_REPOSITORY}
           BRANCH=comparison-screenshots
           BASE_URL="https://raw.githubusercontent.com/${REPO}/${BRANCH}/artifacts"
-          COMMENT="### Snapshot Test Results\n"
-
-          # success ディレクトリ内の画像リンクを追加
-          COMMENT+="\n**Success:**\n"
-          for file in artifacts/success/*.png; do
-            filename=$(basename "$file")
-            COMMENT+="- [${filename}](${BASE_URL}/success/${filename})\n"
-          done
-
-          # failed ディレクトリ内の画像リンクを追加
-          COMMENT+="\n**Failed:**\n"
-          for file in artifacts/failed/*.png; do
-            filename=$(basename "$file")
-            COMMENT+="- [${filename}](${BASE_URL}/failed/${filename})\n"
-          done
-
-          # diffs ディレクトリ内の画像リンクを追加
-          COMMENT+="\n**Diffs:**\n"
-          for file in artifacts/diffs/*.png; do
-            filename=$(basename "$file")
-            COMMENT+="- [${filename}](${BASE_URL}/diffs/${filename})\n"
-          done
-
-          echo "$COMMENT" > comment.md
-          echo "::set-output name=body::$(cat comment.md)"
+          
+          COMMENT="<table>
+          <thead>
+          <tr>
+          <th>既存</th>
+          <th>差分</th>
+          <th>今回</th>
+          </tr>
+          </thead>
+          <tbody>
+          "
+                    for file in artifacts/success/*.png; do
+                      filename=$(basename "$file")
+                      COMMENT+="<tr>
+          <td><img src=\"${BASE_URL}/success/${filename}\" width=\"300\"></td>
+          <td><img src=\"${BASE_URL}/diffs/${filename}\" width=\"300\"></td>
+          <td><img src=\"${BASE_URL}/failed/${filename}\" width=\"300\"></td>
+          </tr>
+          "
+                    done
+                    COMMENT+="</tbody>
+          </table>"
+                    echo "$COMMENT" > comment.md
+                    echo "::set-output name=body::$(cat comment.md)"
 
       - name: PR にコメント投稿
-        if: failure()
         uses: peter-evans/create-or-update-comment@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -170,9 +170,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # GitHub Issue を作成
-          ISSUE_URL=$(gh issue create --title "Snapshot Test Failures" --body "Snapshot tests failed. See the images below." --repo ${{ github.repository }} --label snapshot-test --json url | jq -r '.url')
+          echo "Creating GitHub Issue..."
           
+          # Issue を作成
+          ISSUE_NUMBER=$(gh issue create --title "Snapshot Test Failures" --body "Snapshot tests failed. See the images below." --repo ${{ github.repository }} --label snapshot-test | awk '{print $NF}')
+
+          if [[ -z "$ISSUE_NUMBER" ]]; then
+            echo "Error: Issue creation failed"
+            exit 1
+          fi
+
+          ISSUE_URL="https://github.com/${{ github.repository }}/issues/${ISSUE_NUMBER}"
           echo "Issue created: $ISSUE_URL"
 
           # 画像を imgur にアップロード（GitHub API では直接アップロード不可のため、外部サービスを利用）
@@ -202,7 +210,7 @@ jobs:
           done
 
           # GitHub Issue にコメントとして画像を追加
-          gh issue comment "$ISSUE_URL" --body "$(cat snapshot_summary.md)" --repo ${{ github.repository }}
+          gh issue comment "$ISSUE_NUMBER" --body "$(cat snapshot_summary.md)" --repo ${{ github.repository }}
 
 #      - name: Upload success, failed, and diff images to GitHub Release
 #        if: failure()

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -137,20 +137,20 @@ jobs:
           BRANCH=comparison-screenshots
           BASE_URL="https://raw.githubusercontent.com/${REPO}/${BRANCH}/artifacts"
           
-          # rows 変数に各画像のテーブル行を連結
+          # rows 変数に各画像の行を作成（改行を入れるため $'…\n' を使用）
           rows=""
           for file in artifacts/success/*.png; do
             filename=$(basename "$file")
-            rows="${rows}    <tr>\n"
-            rows="${rows}      <td><img src=\"${BASE_URL}/success/${filename}\" width=\"300\"></td>\n"
-            rows="${rows}      <td><img src=\"${BASE_URL}/diffs/${filename}\" width=\"300\"></td>\n"
-            rows="${rows}      <td><img src=\"${BASE_URL}/failed/${filename}\" width=\"300\"></td>\n"
-            rows="${rows}    </tr>\n"
+            rows="${rows}"$'    <tr>\n'
+            rows="${rows}"$'      <td><img src="'${BASE_URL}'/success/'${filename}'" width="300"></td>\n'
+            rows="${rows}"$'      <td><img src="'${BASE_URL}'/diffs/'${filename}'" width="300"></td>\n'
+            rows="${rows}"$'      <td><img src="'${BASE_URL}'/failed/'${filename}'" width="300"></td>\n'
+            rows="${rows}"$'    </tr>\n'
           done
           if [ -z "$rows" ]; then
-            rows="    <tr><td colspan='3'>No images found</td></tr>\n"
+            rows=$'    <tr><td colspan="3">No images found</td></tr>\n'
           fi
-
+          
           # ヒアドキュメントでテーブル全体を生成
           comment=$(cat <<EOF
           <table>
@@ -167,7 +167,12 @@ jobs:
           EOF
           )
           echo "$comment" > comment.md
-          echo "::set-output name=body::$(cat comment.md)"
+          # 新しい方法で出力を設定
+          {
+            echo "body<<EOF"
+            cat comment.md
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: PR にコメント投稿
         if: ${{ failure() }}

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -133,27 +133,79 @@ jobs:
               --data-binary @$file
           done
 
-      - name: Comment on PR with snapshot diffs from Release
+#      - name: Comment on PR with snapshot diffs from Release
+#        if: failure()
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        run: |
+#          COMMENT_BODY="🚨 **Snapshotテストで差分が発生しています** 🚨\n\n"
+#          RELEASE_URL="https://github.com/${{ github.repository }}/releases/download/snapshot-diff"
+#      
+#          for file in artifacts/diffs/*.png; do
+#            IMAGE_URL="$RELEASE_URL/$(basename "$file")"
+#            COMMENT_BODY+="<img src=\"$IMAGE_URL\" width=\"300\">\n\n"
+#          done
+#      
+#          # JSONとして正しくエスケープする
+#          ESCAPED_BODY=$(echo "$COMMENT_BODY" | jq -Rs .)
+#      
+#          curl -X POST \
+#            -H "Authorization: token $GITHUB_TOKEN" \
+#            -H "Accept: application/vnd.github+json" \
+#            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+#            -d "{\"body\": $ESCAPED_BODY}"
+
+      - name: Generate Markdown table for PR comment
         if: failure()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        id: generate_markdown
         run: |
-          COMMENT_BODY="🚨 **Snapshotテストで差分が発生しています** 🚨\n\n"
+          # Releasesに保存された画像のURLベース
           RELEASE_URL="https://github.com/${{ github.repository }}/releases/download/snapshot-diff"
+          
+          # Cacheから取得する画像（既存の成功スナップショット）
+          EXISTING_DIR="./citest02/Snapshots/__Snapshots__/SnapshotFilePath"
       
-          for file in artifacts/diffs/*.png; do
-            IMAGE_URL="$RELEASE_URL/$(basename "$file")"
-            COMMENT_BODY+="<img src=\"$IMAGE_URL\" width=\"300\">\n\n"
+          # 差分画像のあるディレクトリ
+          DIFF_DIR="./artifacts/diffs"
+      
+          # PRにコメントするMarkdownを生成
+          echo "COMMENT_MARKDOWN<<EOF" >> $GITHUB_ENV
+          echo "### 画像名" >> $GITHUB_ENV
+          echo "" >> $GITHUB_ENV
+          echo "| 既存 | 差分 | 新規 |" >> $GITHUB_ENV
+          echo "| -- | -- | -- |" >> $GITHUB_ENV
+      
+          for diff_file in "$DIFF_DIR"/*.png; do
+            filename=$(basename "$diff_file")
+      
+            # 既存画像のURL
+            existing_url="$RELEASE_URL/$filename"
+      
+            # 差分画像のURL（Artifactsにアップロードしたものを使用）
+            diff_url="$RELEASE_URL/$filename"
+      
+            # 新規画像（今は未アップロードなので空白）
+            new_url="(未アップロード)"
+      
+            echo "| <img src=\"$existing_url\" width=\"300\"> | <img src=\"$diff_url\" width=\"300\"> | $new_url |" >> $GITHUB_ENV
           done
       
-          # JSONとして正しくエスケープする
-          ESCAPED_BODY=$(echo "$COMMENT_BODY" | jq -Rs .)
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Comment on PR with formatted snapshot diffs
+        if: failure()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          token: ${{ secrets.MY_PAT }}
+          message: |
+            🚨 **Snapshotテストで差分が発生しています** 🚨
       
-          curl -X POST \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-            -d "{\"body\": $ESCAPED_BODY}"
+            ${{ env.COMMENT_MARKDOWN }}
+      
+            ---
+            🔗 **詳細画像はこちらから**  
+            [📥 Artifactsをダウンロード](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)
+
 
       # Issueにあげて公開URLを取得すると良さそう
       - name: Cache VRT snapshots

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -119,21 +119,56 @@ jobs:
             echo "ENCODED_IMAGES=" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Comment on PR with snapshot diffs and Artifact link
-        if: failure() && steps.encode_diff_images.outputs.ENCODED_IMAGES != ''
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          token: ${{ secrets.MY_PAT }}
-          message: |
-            🚨 **Snapshotテストで差分が発生しています** 🚨
+#      - name: Comment on PR with snapshot diffs and Artifact link
+#        if: failure() && steps.encode_diff_images.outputs.ENCODED_IMAGES != ''
+#        uses: marocchino/sticky-pull-request-comment@v2
+#        with:
+#          token: ${{ secrets.MY_PAT }}
+#          message: |
+#            🚨 **Snapshotテストで差分が発生しています** 🚨
+#
+#            （縮小表示のため画像が小さいですが、差分は以下で確認できます）
+#
+#            ${{ steps.encode_diff_images.outputs.ENCODED_IMAGES }}
+#
+#            詳細な画像はこちらからダウンロードしてください。  
+#            [📥 Artifactsをダウンロード](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)
+      - name: Upload diff images to GitHub Issue and comment on PR
+        if: failure()
+        env:
+          GITHUB_TOKEN: ${{ secrets.MY_PAT }}
+        run: |
+          IMAGE_MARKDOWN=""
+          for file in artifacts/diffs/*.png; do
+            # Issueに画像コメントを投稿
+            upload_response=$(curl -s -X POST \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+              -d "{\"body\":\"![Diff Image $(basename "$file")]($(basename "$file"))\"}")
+      
+            # コメントから画像のURLを抽出
+            comment_url=$(echo "$upload_response" | jq -r '.html_url')
+      
+            # コメントをAPIから取得し直して画像の正確なURLを取得
+            comment_body=$(curl -s -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "$comment_url" | grep -o       'https://user-images.githubusercontent.com[^)]*')
+      
+            if [ -z "$comment_body" ]; then
+              echo "Failed to upload $file"
+              exit 1
+            fi
+      
+            IMAGE_MARKDOWN+="**$(basename "$file")**\n\n![$(basename "$file")]($comment_body)\n\n"
+          done
+      
+          # まとめてPRコメントを投稿
+          curl -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            -d "{\"body\": \"🚨 **Snapshotテストで差分が発生しています** 🚨\\n\\n${IMAGE_MARKDOWN}\"}"
 
-            （縮小表示のため画像が小さいですが、差分は以下で確認できます）
-
-            ${{ steps.encode_diff_images.outputs.ENCODED_IMAGES }}
-
-            詳細な画像はこちらからダウンロードしてください。  
-            [📥 Artifactsをダウンロード](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)
-
+      # Issueにあげて公開URLを取得すると良さそう
       - name: Cache VRT snapshots
         if: always()
         uses: actions/cache/save@v3

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -138,35 +138,32 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          COMMENT_BODY="🚨 **Snapshotテストで差分が発生しています** 🚨"
-          COMMENT_BODY+="\n\n以下に画像の差分を表示します。\n"
-          COMMENT_BODY+="\n詳細な画像はこちらからダウンロードしてください。\n"
-          COMMENT_BODY+="[📥 Artifactsをダウンロード](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)\n\n"
-      
           RELEASE_URL="https://github.com/${{ github.repository }}/releases/download/snapshot-diff"
-          
+      
+          # コメント本文を printf で改行付きで構築
+          COMMENT_BODY=$(printf "🚨 **Snapshotテストで差分が発生しています** 🚨\n\n")
+          COMMENT_BODY+=$(printf "以下に画像の差分を表示します。\n\n")
+          COMMENT_BODY+=$(printf "詳細な画像はこちらからダウンロードしてください。\n")
+          COMMENT_BODY+=$(printf "[📥 Artifactsをダウンロード](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)\n\n")
+      
           COUNT=1
           for file in artifacts/diffs/*.png; do
             IMAGE_URL="$RELEASE_URL/$(basename "$file")"
-            
-            COMMENT_BODY+="\n### 画像${COUNT}\n\n"
-            COMMENT_BODY+="| 既存 | 差分 | 新規 |\n"
-            COMMENT_BODY+="| -- | -- | -- |\n"
-            COMMENT_BODY+="| 空 | <img src=\"$IMAGE_URL\" width=\"300\"> | 空 |\n"
+      
+            COMMENT_BODY+=$(printf "### 画像${COUNT}\n\n")
+            COMMENT_BODY+=$(printf "| 既存 | 差分 | 新規 |\n")
+            COMMENT_BODY+=$(printf "| -- | -- | -- |\n")
+            COMMENT_BODY+=$(printf "| 空 | <img src=\"$IMAGE_URL\" width=\"300\"> | 空 |\n\n")
       
             COUNT=$((COUNT + 1))
           done
       
-          # JSONエスケープを適用せず、実際の改行を保持したままコメントを作成
+          # JSONとして正しくエスケープし、GitHub API に送信
           curl -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-            --data-binary @- <<EOF
-          {
-            "body": $(jq -Rs . <<< "$COMMENT_BODY")
-          }
-          EOF
+            -d "$(jq -Rs --arg body "$COMMENT_BODY" '{body: $body}' <<< "")"
 
       # Issueにあげて公開URLを取得すると良さそう
       - name: Cache VRT snapshots

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -133,40 +133,34 @@ jobs:
 #
 #            詳細な画像はこちらからダウンロードしてください。  
 #            [📥 Artifactsをダウンロード](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)
-      - name: Upload diff images to GitHub Issue and comment on PR
+      - name: Upload images to PR comments and get image URLs
         if: failure()
+        id: upload_images
         env:
-          GITHUB_TOKEN: ${{ secrets.MY_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          IMAGE_MARKDOWN=""
+          IMAGE_URLS=""
           for file in artifacts/diffs/*.png; do
-            # Issueに画像コメントを投稿
-            upload_response=$(curl -s -X POST \
+            upload_response=$(curl -X POST \
               -H "Authorization: token $GITHUB_TOKEN" \
               -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-              -d "{\"body\":\"![Diff Image $(basename "$file")]($(basename "$file"))\"}")
+              -H "Content-Type: $(file -b --mime-type "$file")" \
+              --data-binary @"$file" \
+              "https://uploads.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+              | jq -r '.body' \
+              | grep -o 'https://user-images.githubusercontent.com[^)]*')
       
-            # コメントから画像のURLを抽出
-            comment_url=$(echo "$upload_response" | jq -r '.html_url')
-      
-            # コメントをAPIから取得し直して画像の正確なURLを取得
-            comment_body=$(curl -s -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "$comment_url" | grep -o       'https://user-images.githubusercontent.com[^)]*')
-      
-            if [ -z "$comment_body" ]; then
-              echo "Failed to upload $file"
-              exit 1
-            fi
-      
-            IMAGE_MARKDOWN+="**$(basename "$file")**\n\n![$(basename "$file")]($comment_body)\n\n"
+            IMAGE_MARKDOWN="${IMAGE_MARKDOWN}![$(basename "$file")]($upload_response)\n\n"
           done
-      
-          # まとめてPRコメントを投稿
-          curl -X POST \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-            -d "{\"body\": \"🚨 **Snapshotテストで差分が発生しています** 🚨\\n\\n${IMAGE_MARKDOWN}\"}"
+
+      - name: Comment on PR with uploaded images
+        if: failure()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          message: |
+            🚨 **Snapshotテストで差分が発生しています** 🚨
+            ${{ env.IMAGE_MARKDOWN }}
 
       # Issueにあげて公開URLを取得すると良さそう
       - name: Cache VRT snapshots

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -164,18 +164,18 @@ jobs:
 
           echo "Issue successfully created!"
 
-      - name: 必要なツールをインストール
-        if: failure()
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y jq curl
+#      - name: 必要なツールをインストール
+#        if: failure()
+#        run: |
+#          sudo apt-get update
+#          sudo apt-get install -y jq curl
 
       - name: 画像をGitHub Issueにアップロード
         if: failure()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ISSUE_NUMBER=1  # 画像をアップロードするIssueの番号を指定
+          ISSUE_NUMBER=7  # 画像をアップロードするIssueの番号を指定
           PR_NUMBER=${{ github.event.pull_request.number }}
 
           # 画像アップロード用のコメントを作成

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -208,6 +208,64 @@ jobs:
                 "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
                 -d "$(jq -Rs --arg body "$COMMENT_BODY" '{body: $body}' <<< "")"
 
+      - name: Report Snapshot Diffs via GitHub Checks
+        if: failure()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "::group::Processing snapshot images for GitHub Checks"
+      
+          CHECK_NAME="Snapshot Diff Report"
+          GITHUB_API="https://api.github.com/repos/${{ github.repository }}/check-runs"
+      
+          # GitHub Checks の開始
+          CHECK_RUN=$(curl -s -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            $GITHUB_API \
+            -d "{
+              \"name\": \"$CHECK_NAME\",
+              \"head_sha\": \"${{ github.event.pull_request.head.sha }}\",
+              \"status\": \"in_progress\"
+            }")
+      
+          CHECK_ID=$(echo "$CHECK_RUN" | jq -r '.id')
+      
+          # コメント用変数
+          CHECK_SUMMARY="🚨 **Snapshotテストで差分が発生しました** 🚨\n\n"
+      
+          for file in artifacts/diffs/*.png; do
+            BASENAME=$(basename "$file")
+            FILENAME=${BASENAME#diff_}
+      
+            # 画像をBase64エンコード
+            DIFF_B64=$(base64 -w 0 "$file")
+            SUCCESS_B64=$(base64 -w 0 "artifacts/success/$FILENAME")
+            FAILED_B64=$(base64 -w 0 "artifacts/failed/$FILENAME")
+      
+            # GitHub Checks に表示するMarkdownテーブルを作成
+            CHECK_SUMMARY+="### ${FILENAME}\n\n"
+            CHECK_SUMMARY+="| 既存（成功時） | 差分 | 新規（失敗時） |\n"
+            CHECK_SUMMARY+="| -- | -- | -- |\n"
+            CHECK_SUMMARY+="| <img src=\"data:image/png;base64,${SUCCESS_B64}\" width=\"300\"> | <img src=\"data:image/png;base64,${DIFF_B64}\" width=\"300\"> | <img       src=\"data:image/png;base64,${FAILED_B64}\" width=\"300\"> |\n\n"
+          done
+      
+          # GitHub Checks を更新（結果を登録）
+          curl -s -X PATCH \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "$GITHUB_API/$CHECK_ID" \
+            -d "{
+              \"status\": \"completed\",
+              \"conclusion\": \"failure\",
+              \"output\": {
+                \"title\": \"$CHECK_NAME\",
+                \"summary\": \"$CHECK_SUMMARY\"
+              }
+            }"
+      
+          echo "::endgroup::"
+
       # Issueにあげて公開URLを取得すると良さそう
       - name: Cache VRT snapshots
         if: always()

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -140,6 +140,21 @@ jobs:
       
           echo "RELEASE_ID=$RELEASE_ID" >> $GITHUB_ENV
 
+      - name: Create GitHub Issue for Snapshot Failures
+        run: |
+          echo "Creating GitHub Issue..."
+          ISSUE_JSON=$(gh issue create --title "Snapshot Test Failures" --body "Snapshot tests failed. See the images below." --repo ${{ github.repository }} --label snapshot-test --json number,url || echo "{}")
+          
+          ISSUE_NUMBER=$(echo "$ISSUE_JSON" | jq -r '.number // empty')
+          ISSUE_URL=$(echo "$ISSUE_JSON" | jq -r '.url // empty')
+
+          if [[ -z "$ISSUE_NUMBER" || -z "$ISSUE_URL" ]]; then
+            echo "Error: Failed to create issue"
+            exit 1
+          fi
+
+          echo "Issue created: $ISSUE_URL"
+
       - name: Upload success, failed, and diff images to GitHub Issue
         if: failure()
         env:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -228,35 +228,47 @@ jobs:
       
           CHECK_ID=$(echo "$CHECK_RUN" | jq -r '.id')
       
-          # コメント用変数（JSONエスケープ対応）
+          # コメント用変数
           CHECK_TITLE="🚨 Snapshotテストで差分が発生しました 🚨"
-          CHECK_SUMMARY="🚨 **Snapshotテストで差分が発生しました** 🚨\n\n"
+          CHECK_SUMMARY="🚨 **Snapshotテストで差分が発生しました** 🚨\n\n以下に詳細な画像の差分を表示します。\n\n"
+      
+          # Annotations（行ごとのコメント）
+          ANNOTATIONS=()
       
           for file in artifacts/diffs/*.png; do
             BASENAME=$(basename "$file")
             FILENAME=${BASENAME#diff_}
       
-            # macOS の base64 コマンドを使用（-w 0 を削除）
+            # 画像のBase64エンコード
             DIFF_B64=$(base64 "$file" | tr -d '\n')
             SUCCESS_B64=$(base64 "artifacts/success/$FILENAME" | tr -d '\n')
             FAILED_B64=$(base64 "artifacts/failed/$FILENAME" | tr -d '\n')
       
-            # GitHub Checks に表示するMarkdownテーブルを作成（JSON対応）
+            # GitHub Checks に表示するMarkdownテーブルを作成（Annotations用）
             IMAGE_TABLE="### ${FILENAME}\n\n"
             IMAGE_TABLE+="| 既存（成功時） | 差分 | 新規（失敗時） |\n"
             IMAGE_TABLE+="| -- | -- | -- |\n"
             IMAGE_TABLE+="| ![成功](data:image/png;base64,${SUCCESS_B64}) | ![差分](data:image/png;base64,${DIFF_B64}) | ![失敗](data:image/png;base64,${FAILED_B64}) |\n\n"
       
             CHECK_SUMMARY+="$IMAGE_TABLE"
+      
+            # Annotations に追加
+            ANNOTATIONS+=("$(jq -n \
+              --arg path "$FILENAME" \
+              --arg message "Snapshot difference found: $FILENAME" \
+              --arg annotation_level "warning" \
+              --arg title "Snapshot Diff: $FILENAME" \
+              '{path: $path, message: $message, annotation_level: $annotation_level, title: $title}')")
           done
       
-          # GitHub Checks を更新（結果を登録）
+          # GitHub Checks を更新（Annotations を含める）
           curl -s -X PATCH \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             "$GITHUB_API/$CHECK_ID" \
             -d "$(jq -n --arg status "completed" --arg conclusion "failure" --arg title "$CHECK_TITLE" --arg summary "$CHECK_SUMMARY" \
-              '{status: $status, conclusion: $conclusion, output: {title: $title, summary: $summary}}')"
+              --argjson annotations "[${ANNOTATIONS[*]}]" \
+              '{status: $status, conclusion: $conclusion, output: {title: $title, summary: $summary, annotations: $annotations}}')"
       
           echo "::endgroup::"
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -141,28 +141,28 @@ jobs:
 #          echo "RELEASE_ID=$RELEASE_ID" >> $GITHUB_ENV
 
       - name: Create GitHub Issue for Snapshot Failures
-        if: failure()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Creating GitHub Issue..."
 
-          # GitHub CLI のバージョンと認証状態を確認
-          gh --version
-          gh auth status
-          
-          # Issue 作成を試行
-          ISSUE_OUTPUT=$(gh issue create --title "Snapshot Test Failures" --body "Snapshot tests failed. See the images below." --label snapshot-test --repo ${{ github.repository }} 2>&1)
-          EXIT_CODE=$?
+          # デバッグモードを有効化
+          set -x
 
-          echo "Issue command output: $ISSUE_OUTPUT"
-          
+          # Issue 作成を試行
+          gh issue create --title "Snapshot Test Failures" --body "Snapshot tests failed. See the images below." --label snapshot-test --repo ${{ github.repository }}
+
+          # コマンドの終了ステータスを確認
+          EXIT_CODE=$?
+          set +x # デバッグモード終了
+
           if [[ $EXIT_CODE -ne 0 ]]; then
             echo "Error: Failed to create issue (Exit Code: $EXIT_CODE)"
             exit 1
           fi
 
           echo "Issue successfully created!"
+
 
       - name: Upload success, failed, and diff images to GitHub Issue
         if: failure()

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -29,16 +29,16 @@ jobs:
           echo $default | cat >default
           echo Using default scheme: $default
 
-      - name: Build
-        env:
-          scheme: ${{ 'default' }}
-          platform: ${{ 'iOS Simulator' }}
-        run: |
-          device=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//"`
-          if [ $scheme = default ]; then scheme=$(cat default); fi
-          if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
-          file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
-          xcodebuild build-for-testing -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=$platform,name=iPhone 16"
+#      - name: Build
+#        env:
+#          scheme: ${{ 'default' }}
+#          platform: ${{ 'iOS Simulator' }}
+#        run: |
+#          device=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//"`
+#          if [ $scheme = default ]; then scheme=$(cat default); fi
+#          if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
+#          file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
+#          xcodebuild build-for-testing -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=$platform,name=iPhone 16"
 
       - name: Restore VRT snapshots
         uses: actions/cache@v3

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -141,15 +141,24 @@ jobs:
           echo "RELEASE_ID=$RELEASE_ID" >> $GITHUB_ENV
 
       - name: Create GitHub Issue for Snapshot Failures
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Creating GitHub Issue..."
-          ISSUE_JSON=$(gh issue create --title "Snapshot Test Failures" --body "Snapshot tests failed. See the images below." --repo ${{ github.repository }} --label snapshot-test --json number,url || echo "{}")
           
-          ISSUE_NUMBER=$(echo "$ISSUE_JSON" | jq -r '.number // empty')
-          ISSUE_URL=$(echo "$ISSUE_JSON" | jq -r '.url // empty')
+          ISSUE_OUTPUT=$(gh issue create --title "Snapshot Test Failures" --body "Snapshot tests failed. See the images below." --label snapshot-test --repo ${{ github.repository }} 2>&1)
 
-          if [[ -z "$ISSUE_NUMBER" || -z "$ISSUE_URL" ]]; then
+          if [[ $? -ne 0 ]]; then
             echo "Error: Failed to create issue"
+            echo "$ISSUE_OUTPUT"
+            exit 1
+          fi
+
+          # 作成した Issue の URL を取得
+          ISSUE_URL=$(gh issue list --repo ${{ github.repository }} --state open --limit 1 --json url --jq '.[0].url')
+
+          if [[ -z "$ISSUE_URL" ]]; then
+            echo "Error: Could not retrieve issue URL"
             exit 1
           fi
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -167,7 +167,7 @@ jobs:
             rows=$'    <tr><td colspan="3">No images found</td></tr>\n'
           fi
           
-          comment=$(cat <<EOF
+          comment=$(cat <<EOF | sed '/./,$!d'
           <table>
             <thead>
               <tr>

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -86,7 +86,7 @@ jobs:
             filename=$(basename "$failed")
             success="$SUCCESS_DIR/$filename"
             if [ -f "$success" ]; then
-              diff_file="$DIFF_DIR/diff_$filename"
+              diff_file="$DIFF_DIR/$filename"
               compare "$success" "$failed" "$diff_file" || true
       
               # 成功・失敗画像もコピー

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -29,16 +29,16 @@ jobs:
           echo $default | cat >default
           echo Using default scheme: $default
 
-#      - name: Build
-#        env:
-#          scheme: ${{ 'default' }}
-#          platform: ${{ 'iOS Simulator' }}
-#        run: |
-#          device=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//"`
-#          if [ $scheme = default ]; then scheme=$(cat default); fi
-#          if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
-#          file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
-#          xcodebuild build-for-testing -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=$platform,name=iPhone 16"
+      - name: Build
+        env:
+          scheme: ${{ 'default' }}
+          platform: ${{ 'iOS Simulator' }}
+        run: |
+          device=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//"`
+          if [ $scheme = default ]; then scheme=$(cat default); fi
+          if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
+          file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
+          xcodebuild build-for-testing -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=$platform,name=iPhone 16"
 
       - name: Restore VRT snapshots
         uses: actions/cache@v3

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -129,23 +129,25 @@ jobs:
 
       - name: コメント本文を生成
         if: ${{ failure() }}
-        id: generate_comment
         shell: bash
         run: |
           shopt -s nullglob
-          # 各ディレクトリ内のファイル名のユニオンを作成
-          declare -A files
-          for file in artifacts/success/*.png; do
-            filename=$(basename "$file")
-            files["$filename"]=1
-          done
-          for file in artifacts/diffs/*.png; do
-            filename=$(basename "$file")
-            files["$filename"]=1
-          done
-          for file in artifacts/failed/*.png; do
-            filename=$(basename "$file")
-            files["$filename"]=1
+          # 各ディレクトリからユニークなファイル名を集める（連想配列の代替）
+          files=()
+          for file in artifacts/success/*.png artifacts/diffs/*.png artifacts/failed/*.png; do
+            if [ -e "$file" ]; then
+              fname=$(basename "$file")
+              found=0
+              for existing in "${files[@]}"; do
+                if [ "$existing" = "$fname" ]; then
+                  found=1
+                  break
+                fi
+              done
+              if [ $found -eq 0 ]; then
+                files+=("$fname")
+              fi
+            fi
           done
           
           REPO=${GITHUB_REPOSITORY}
@@ -153,12 +155,11 @@ jobs:
           BASE_URL="https://raw.githubusercontent.com/${REPO}/${BRANCH}/artifacts"
           
           rows=""
-          # 集めた全ファイル名について行を生成
-          for filename in "${!files[@]}"; do
+          for fname in "${files[@]}"; do
             rows="${rows}"$'    <tr>\n'
-            rows="${rows}"$'      <td><img src="'${BASE_URL}'/success/'${filename}'" width="300"></td>\n'
-            rows="${rows}"$'      <td><img src="'${BASE_URL}'/diffs/'${filename}'" width="300"></td>\n'
-            rows="${rows}"$'      <td><img src="'${BASE_URL}'/failed/'${filename}'" width="300"></td>\n'
+            rows="${rows}"$'      <td><img src="'${BASE_URL}'/success/'${fname}'" width="300"></td>\n'
+            rows="${rows}"$'      <td><img src="'${BASE_URL}'/diffs/'${fname}'" width="300"></td>\n'
+            rows="${rows}"$'      <td><img src="'${BASE_URL}'/failed/'${fname}'" width="300"></td>\n'
             rows="${rows}"$'    </tr>\n'
           done
           if [ -z "$rows" ]; then
@@ -179,12 +180,10 @@ jobs:
           </table>
           EOF
           )
+          # 生成したコメントをファイルに書き出す
           echo "$comment" > comment.md
-          {
-            echo "body<<EOF"
-            cat comment.md
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+          # ログ出力して内容を確認
+          cat comment.md
 
       - name: PR にコメント投稿
         if: ${{ failure() }}
@@ -192,9 +191,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
-          body: ${{ steps.generate_comment.outputs.body }}
-
-
+          body-path: comment.md
 
 #      - name: Create GitHub Release (if not exists)
 #        if: failure()

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -165,11 +165,13 @@ jobs:
           echo "Issue successfully created!"
 
       - name: 必要なツールをインストール
+        if: failure()
         run: |
           sudo apt-get update
           sudo apt-get install -y jq curl
 
       - name: 画像をGitHub Issueにアップロード
+        if: failure()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -132,33 +132,43 @@ jobs:
         id: generate_comment
         shell: bash
         run: |
+          shopt -s nullglob
           REPO=${GITHUB_REPOSITORY}
           BRANCH=comparison-screenshots
           BASE_URL="https://raw.githubusercontent.com/${REPO}/${BRANCH}/artifacts"
           
-          COMMENT="<table>
-          <thead>
-          <tr>
-          <th>既存</th>
-          <th>差分</th>
-          <th>今回</th>
-          </tr>
-          </thead>
-          <tbody>
-          "
-                    for file in artifacts/success/*.png; do
-                      filename=$(basename "$file")
-                      COMMENT+="<tr>
-          <td><img src=\"${BASE_URL}/success/${filename}\" width=\"300\"></td>
-          <td><img src=\"${BASE_URL}/diffs/${filename}\" width=\"300\"></td>
-          <td><img src=\"${BASE_URL}/failed/${filename}\" width=\"300\"></td>
-          </tr>
-          "
-                    done
-                    COMMENT+="</tbody>
-          </table>"
-                    echo "$COMMENT" > comment.md
-                    echo "::set-output name=body::$(cat comment.md)"
+          comment=$(cat <<'EOF'
+<table>
+  <thead>
+    <tr>
+      <th>既存</th>
+      <th>差分</th>
+      <th>今回</th>
+    </tr>
+  </thead>
+  <tbody>
+EOF
+)
+          found=0
+          for file in artifacts/success/*.png; do
+            found=1
+            filename=$(basename "$file")
+            comment+=$(cat <<EOF
+    <tr>
+      <td><img src="${BASE_URL}/success/${filename}" width="300"></td>
+      <td><img src="${BASE_URL}/diffs/${filename}" width="300"></td>
+      <td><img src="${BASE_URL}/failed/${filename}" width="300"></td>
+    </tr>
+EOF
+)
+          done
+          if [ $found -eq 0 ]; then
+            comment+="    <tr><td colspan='3'>No images found</td></tr>"
+          fi
+          comment+="  </tbody>
+</table>"
+          echo "$comment" > comment.md
+          echo "::set-output name=body::$(cat comment.md)"
 
       - name: PR にコメント投稿
         if: failure()
@@ -167,6 +177,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: ${{ steps.generate_comment.outputs.body }}
+
 
 
 #      - name: Create GitHub Release (if not exists)

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -146,11 +146,14 @@ jobs:
             COMMENT_BODY+="<img src=\"$IMAGE_URL\" width=\"300\">\n\n"
           done
       
+          # JSONとして正しくエスケープする
+          ESCAPED_BODY=$(echo "$COMMENT_BODY" | jq -Rs .)
+      
           curl -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-            -d "{\"body\": \"$COMMENT_BODY\"}"
+            -d "{\"body\": $ESCAPED_BODY}"
 
       # Issueにあげて公開URLを取得すると良さそう
       - name: Cache VRT snapshots

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -238,10 +238,10 @@ jobs:
             BASENAME=$(basename "$file")
             FILENAME=${BASENAME#diff_}
       
-            # 画像をBase64エンコード
-            DIFF_B64=$(base64 -w 0 "$file")
-            SUCCESS_B64=$(base64 -w 0 "artifacts/success/$FILENAME")
-            FAILED_B64=$(base64 -w 0 "artifacts/failed/$FILENAME")
+            # macOS の base64 コマンドを使用（-w 0 を削除）
+            DIFF_B64=$(base64 "$file" | tr -d '\n')
+            SUCCESS_B64=$(base64 "artifacts/success/$FILENAME" | tr -d '\n')
+            FAILED_B64=$(base64 "artifacts/failed/$FILENAME" | tr -d '\n')
       
             # GitHub Checks に表示するMarkdownテーブルを作成
             CHECK_SUMMARY+="### ${FILENAME}\n\n"

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -133,12 +133,12 @@ jobs:
 #
 #            詳細な画像はこちらからダウンロードしてください。  
 #            [📥 Artifactsをダウンロード](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)
-      - name: Upload diff images as Artifact
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: snapshot-diffs
-          path: artifacts/diffs/*.png
+#      - name: Upload diff images as Artifact
+#        if: failure()
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: snapshot-diffs
+#          path: artifacts/diffs/*.png
 
       - name: Upload diff images to Issue comment
         if: failure()

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -77,14 +77,21 @@ jobs:
           FAILED_DIR="./citest02/Snapshots/__Snapshots__/Failure/SnapshotFilePath"
           SUCCESS_DIR="./citest02/Snapshots/__Snapshots__/SnapshotFilePath"
           DIFF_DIR="$(pwd)/artifacts/diffs"
-          mkdir -p "$DIFF_DIR"
-
+          SUCCESS_OUT_DIR="$(pwd)/artifacts/success"
+          FAILED_OUT_DIR="$(pwd)/artifacts/failed"
+      
+          mkdir -p "$DIFF_DIR" "$SUCCESS_OUT_DIR" "$FAILED_OUT_DIR"
+      
           for failed in "$FAILED_DIR"/*; do
             filename=$(basename "$failed")
             success="$SUCCESS_DIR/$filename"
             if [ -f "$success" ]; then
               diff_file="$DIFF_DIR/diff_$filename"
               compare "$success" "$failed" "$diff_file" || true
+      
+              # 成功・失敗画像もコピー
+              cp "$success" "$SUCCESS_OUT_DIR/$filename"
+              cp "$failed" "$FAILED_OUT_DIR/$filename"
             fi
           done
 
@@ -119,18 +126,41 @@ jobs:
       
           echo "RELEASE_ID=$RELEASE_ID" >> $GITHUB_ENV
 
-      - name: Upload diff images to GitHub Release
+      - name: Upload success, failed, and diff images to GitHub Release
         if: failure()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          for file in artifacts/diffs/*.png; do
-            echo "Uploading $file to GitHub Release..."
+          UPLOAD_URL="https://uploads.github.com/repos/${{ github.repository }}/releases/$RELEASE_ID/assets"
+      
+          # 成功画像のアップロード
+          for file in artifacts/success/*.png; do
+            echo "Uploading success image: $file"
             curl -s -X POST \
               -H "Authorization: token $GITHUB_TOKEN" \
               -H "Content-Type: application/octet-stream" \
-              "https://uploads.github.com/repos/${{ github.repository }}/releases/$RELEASE_ID/assets?name=$(basename "$file")" \
-              --data-binary @$file
+              "$UPLOAD_URL?name=success_$(basename "$file")" \
+              --data-binary @"$file"
+          done
+      
+          # 失敗画像のアップロード
+          for file in artifacts/failed/*.png; do
+            echo "Uploading failed image: $file"
+            curl -s -X POST \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Content-Type: application/octet-stream" \
+              "$UPLOAD_URL?name=failed_$(basename "$file")" \
+              --data-binary @"$file"
+          done
+      
+          # 差分画像のアップロード
+          for file in artifacts/diffs/*.png; do
+            echo "Uploading diff image: $file"
+            curl -s -X POST \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Content-Type: application/octet-stream" \
+              "$UPLOAD_URL?name=$(basename "$file")" \
+              --data-binary @"$file"
           done
 
       - name: Comment on PR with structured snapshot diffs from Release

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -182,16 +182,16 @@ jobs:
           EOF
           )
     
-              COUNT=1
               for file in artifacts/diffs/*.png; do
                 BASENAME=$(basename "$file")
+                FILENAME=${BASENAME#diff_}  # "diff_" を削除して元のファイル名を取得
                 DIFF_IMAGE_URL="$RELEASE_URL/$BASENAME"
-                SUCCESS_IMAGE_URL="$RELEASE_URL/success_${BASENAME#diff_}"
-                FAILED_IMAGE_URL="$RELEASE_URL/failed_${BASENAME#diff_}"
+                SUCCESS_IMAGE_URL="$RELEASE_URL/success_${FILENAME}"
+                FAILED_IMAGE_URL="$RELEASE_URL/failed_${FILENAME}"
     
                 COMMENT_BODY+=$(cat <<EOF
     
-          ### 画像${COUNT}
+          ### ${FILENAME}
     
           | 既存（成功時） | 差分 | 新規（失敗時） |
           | -- | -- | -- |
@@ -199,7 +199,6 @@ jobs:
     
           EOF
           )
-                COUNT=$((COUNT + 1))
               done
     
               # JSONエスケープを適用し GitHub API に送信

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -138,9 +138,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          COMMENT_BODY="🚨 **Snapshotテストで差分が発生しています** 🚨\n\n"
-          COMMENT_BODY+="以下に画像の差分を表示します。\n\n"
-          COMMENT_BODY+="詳細な画像はこちらからダウンロードしてください。\n"
+          COMMENT_BODY="🚨 **Snapshotテストで差分が発生しています** 🚨"
+          COMMENT_BODY+="\n\n以下に画像の差分を表示します。\n"
+          COMMENT_BODY+="\n詳細な画像はこちらからダウンロードしてください。\n"
           COMMENT_BODY+="[📥 Artifactsをダウンロード](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)\n\n"
       
           RELEASE_URL="https://github.com/${{ github.repository }}/releases/download/snapshot-diff"
@@ -149,22 +149,24 @@ jobs:
           for file in artifacts/diffs/*.png; do
             IMAGE_URL="$RELEASE_URL/$(basename "$file")"
             
-            COMMENT_BODY+="### 画像${COUNT}\n\n"
+            COMMENT_BODY+="\n### 画像${COUNT}\n\n"
             COMMENT_BODY+="| 既存 | 差分 | 新規 |\n"
             COMMENT_BODY+="| -- | -- | -- |\n"
-            COMMENT_BODY+="| 空 | <img src=\"$IMAGE_URL\" width=\"300\"> | 空 |\n\n"
+            COMMENT_BODY+="| 空 | <img src=\"$IMAGE_URL\" width=\"300\"> | 空 |\n"
       
             COUNT=$((COUNT + 1))
           done
       
-          # JSONとして正しくエスケープする
-          ESCAPED_BODY=$(echo "$COMMENT_BODY" | jq -Rs .)
-      
+          # JSONエスケープを適用せず、実際の改行を保持したままコメントを作成
           curl -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-            -d "{\"body\": $ESCAPED_BODY}"
+            --data-binary @- <<EOF
+          {
+            "body": $(jq -Rs . <<< "$COMMENT_BODY")
+          }
+          EOF
 
       # Issueにあげて公開URLを取得すると良さそう
       - name: Cache VRT snapshots

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -163,50 +163,50 @@ jobs:
               --data-binary @"$file"
           done
 
-      - name: Comment on PR with structured snapshot diffs from Release
-        if: failure()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          RELEASE_URL="https://github.com/${{ github.repository }}/releases/download/snapshot-diff"
-      
-          # コメント本文の構築
-          COMMENT_BODY=$(cat <<EOF
-          🚨 **Snapshotテストで差分が発生しています** 🚨
-    
-          以下に画像の差分を表示します。
-    
-          詳細な画像はこちらからダウンロードしてください。
-          [📥 Artifactsをダウンロード](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)
-    
-          EOF
-          )
-    
-              for file in artifacts/diffs/*.png; do
-                BASENAME=$(basename "$file")
-                FILENAME=${BASENAME#diff_}  # "diff_" を削除して元のファイル名を取得
-                DIFF_IMAGE_URL="$RELEASE_URL/$BASENAME"
-                SUCCESS_IMAGE_URL="$RELEASE_URL/success_${FILENAME}"
-                FAILED_IMAGE_URL="$RELEASE_URL/failed_${FILENAME}"
-    
-                COMMENT_BODY+=$(cat <<EOF
-    
-          ### ${FILENAME}
-    
-          | 既存 | 差分 | 今回の変更 |
-          | -- | -- | -- |
-          | <img src="${SUCCESS_IMAGE_URL}" width="300"> | <img src="${DIFF_IMAGE_URL}" width="300"> | <img src="${FAILED_IMAGE_URL}" width="300"> |
-    
-          EOF
-          )
-              done
-    
-              # JSONエスケープを適用し GitHub API に送信
-              curl -X POST \
-                -H "Authorization: token $GITHUB_TOKEN" \
-                -H "Accept: application/vnd.github+json" \
-                "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-                -d "$(jq -Rs --arg body "$COMMENT_BODY" '{body: $body}' <<< "")"
+#      - name: Comment on PR with structured snapshot diffs from Release
+#        if: failure()
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        run: |
+#          RELEASE_URL="https://github.com/${{ github.repository }}/releases/download/snapshot-diff"
+#      
+#          # コメント本文の構築
+#          COMMENT_BODY=$(cat <<EOF
+#          🚨 **Snapshotテストで差分が発生しています** 🚨
+#    
+#          以下に画像の差分を表示します。
+#    
+#          詳細な画像はこちらからダウンロードしてください。
+#          [📥 Artifactsをダウンロード](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)
+#    
+#          EOF
+#          )
+#    
+#              for file in artifacts/diffs/*.png; do
+#                BASENAME=$(basename "$file")
+#                FILENAME=${BASENAME#diff_}  # "diff_" を削除して元のファイル名を取得
+#                DIFF_IMAGE_URL="$RELEASE_URL/$BASENAME"
+#                SUCCESS_IMAGE_URL="$RELEASE_URL/success_${FILENAME}"
+#                FAILED_IMAGE_URL="$RELEASE_URL/failed_${FILENAME}"
+#    
+#                COMMENT_BODY+=$(cat <<EOF
+#    
+#          ### ${FILENAME}
+#    
+#          | 既存 | 差分 | 今回の変更 |
+#          | -- | -- | -- |
+#          | <img src="${SUCCESS_IMAGE_URL}" width="300"> | <img src="${DIFF_IMAGE_URL}" width="300"> | <img src="${FAILED_IMAGE_URL}" width="300"> |
+#    
+#          EOF
+#          )
+#              done
+#    
+#              # JSONエスケープを適用し GitHub API に送信
+#              curl -X POST \
+#                -H "Authorization: token $GITHUB_TOKEN" \
+#                -H "Accept: application/vnd.github+json" \
+#                "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+#                -d "$(jq -Rs --arg body "$COMMENT_BODY" '{body: $body}' <<< "")"
 
       - name: Report Snapshot Diffs via GitHub Checks
         if: failure()

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -116,6 +116,62 @@ jobs:
           name: snapshot-failed
           path: artifacts/failed/*.png
 
+      - name: 比較用ブランチ作成 & 画像をコミット
+        run: |
+          # Git のユーザー設定（必要に応じて）
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          # 新しい orphan ブランチを作成
+          git checkout --orphan comparison-screenshots
+          git reset --hard
+          # artifacts ディレクトリを追加
+          git add artifacts
+          git commit -m "Add snapshot test screenshots for comparison"
+          # ブランチを強制プッシュ
+          git push origin comparison-screenshots --force
+
+      - name: コメント本文を生成
+        id: generate_comment
+        shell: bash
+        run: |
+          # リポジトリ情報と新しいブランチ名から画像 URL のベースを生成
+          REPO=${GITHUB_REPOSITORY}
+          BRANCH=comparison-screenshots
+          BASE_URL="https://raw.githubusercontent.com/${REPO}/${BRANCH}/artifacts"
+          COMMENT="### Snapshot Test Results\n"
+
+          # success ディレクトリ内の画像リンクを追加
+          COMMENT+="\n**Success:**\n"
+          for file in artifacts/success/*.png; do
+            filename=$(basename "$file")
+            COMMENT+="- [${filename}](${BASE_URL}/success/${filename})\n"
+          done
+
+          # failed ディレクトリ内の画像リンクを追加
+          COMMENT+="\n**Failed:**\n"
+          for file in artifacts/failed/*.png; do
+            filename=$(basename "$file")
+            COMMENT+="- [${filename}](${BASE_URL}/failed/${filename})\n"
+          done
+
+          # diffs ディレクトリ内の画像リンクを追加
+          COMMENT+="\n**Diffs:**\n"
+          for file in artifacts/diffs/*.png; do
+            filename=$(basename "$file")
+            COMMENT+="- [${filename}](${BASE_URL}/diffs/${filename})\n"
+          done
+
+          echo "$COMMENT" > comment.md
+          echo "::set-output name=body::$(cat comment.md)"
+
+      - name: PR にコメント投稿
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: ${{ steps.generate_comment.outputs.body }}
+
+
 #      - name: Create GitHub Release (if not exists)
 #        if: failure()
 #        env:
@@ -140,61 +196,11 @@ jobs:
 #      
 #          echo "RELEASE_ID=$RELEASE_ID" >> $GITHUB_ENV
 
-      - name: Create GitHub Issue for Snapshot Failures
-        if: failure()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "Creating GitHub Issue..."
-
-          # デバッグモードを有効化
-          set -x
-
-          # Issue 作成を試行
-          gh issue create --title "Snapshot Test Failures" --body "Snapshot tests failed. See the images below." --label snapshot-test --repo ${{ github.repository }}
-
-          # コマンドの終了ステータスを確認
-          EXIT_CODE=$?
-          set +x # デバッグモード終了
-
-          if [[ $EXIT_CODE -ne 0 ]]; then
-            echo "Error: Failed to create issue (Exit Code: $EXIT_CODE)"
-            exit 1
-          fi
-
-          echo "Issue successfully created!"
-
 #      - name: 必要なツールをインストール
 #        if: failure()
 #        run: |
 #          sudo apt-get update
 #          sudo apt-get install -y jq curl
-
-      - name: 画像をGitHub Issueにアップロード
-        if: failure()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          ISSUE_NUMBER=7  # 画像をアップロードするIssueの番号を指定
-          PR_NUMBER=${{ github.event.pull_request.number }}
-
-          # 画像アップロード用のコメントを作成
-          echo "Uploading images to issue #$ISSUE_NUMBER..."
-
-          for file in artifacts/success/*.png; do
-            IMAGE_URL=$(gh issue comment $ISSUE_NUMBER --body "![]($(gh issue upload $ISSUE_NUMBER $file))")
-            echo "✅ Success: ![]($IMAGE_URL)" >> snapshot_summary.md
-          done
-
-          for file in artifacts/failed/*.png; do
-            IMAGE_URL=$(gh issue comment $ISSUE_NUMBER --body "![]($(gh issue upload $ISSUE_NUMBER $file))")
-            echo "❌ Failed: ![]($IMAGE_URL)" >> snapshot_summary.md
-          done
-
-          for file in artifacts/diffs/*.png; do
-            IMAGE_URL=$(gh issue comment $ISSUE_NUMBER --body "![]($(gh issue upload $ISSUE_NUMBER $file))")
-            echo "🔄 Diff: ![]($IMAGE_URL)" >> snapshot_summary.md
-          done
 
 #      - name: Upload success, failed, and diff images to GitHub Release
 #        if: failure()

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -16,11 +16,11 @@ jobs:
       - name: Set Xcode version
         run: sudo xcode-select -s /Applications/Xcode_16.0.app
 
-      - name: Print Xcode version
-        run: xcodebuild -version
-
-      - name: Print available simulators
-        run: xcrun simctl list
+#      - name: Print Xcode version
+#        run: xcodebuild -version
+#
+#      - name: Print available simulators
+#        run: xcrun simctl list
 
       - name: Set Default Scheme
         run: |
@@ -56,9 +56,6 @@ jobs:
             echo "No images found in SnapshotFilePath folder."
           fi
 
-      - name: Install ImageMagick on macOS
-        run: brew install imagemagick
-
       - name: Test
         env:
           scheme: ${{ 'default' }}
@@ -70,7 +67,11 @@ jobs:
           file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
           xcodebuild test-without-building -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=$platform,name=iPhone 16"
 
-      - name: Generate diff images for all failed snapshots using ksdiff
+      - name: Install ImageMagick on macOS
+        if: failure()
+        run: brew install imagemagick
+
+      - name: Generate diff images for all failed snapshots using compare
         if: failure()
         run: |
           set -e
@@ -157,9 +158,9 @@ jobs:
           rows=""
           for fname in "${files[@]}"; do
             rows="${rows}"$'    <tr>\n'
-            rows="${rows}"$'      <td><img src="'${BASE_URL}'/success/'${fname}'" width="300"></td>\n'
-            rows="${rows}"$'      <td><img src="'${BASE_URL}'/diffs/'${fname}'" width="300"></td>\n'
-            rows="${rows}"$'      <td><img src="'${BASE_URL}'/failed/'${fname}'" width="300"></td>\n'
+            rows="${rows}"$'      <td>'${fname}'<br><img src="'${BASE_URL}'/success/'${fname}'" width="300"></td>\n'
+            rows="${rows}"$'      <td>'${fname}'<br><img src="'${BASE_URL}'/diffs/'${fname}'" width="300"></td>\n'
+            rows="${rows}"$'      <td>'${fname}'<br><img src="'${BASE_URL}'/failed/'${fname}'" width="300"></td>\n'
             rows="${rows}"$'    </tr>\n'
           done
           if [ -z "$rows" ]; then
@@ -193,119 +194,6 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body-path: comment.md
 
-#      - name: Create GitHub Release (if not exists)
-#        if: failure()
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        run: |
-#          RELEASE_NAME="snapshot-diff-release"
-#          EXISTING_RELEASE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-#            "https://api.github.com/repos/${{ github.repository }}/releases" | jq -r ".[] | select(.name==\"$RELEASE_NAME\") | .id")
-#      
-#          if [ -z "$EXISTING_RELEASE" ]; then
-#            echo "Creating new release..."
-#            RESPONSE=$(curl -s -X POST \
-#              -H "Authorization: token $GITHUB_TOKEN" \
-#              -H "Accept: application/vnd.github.v3+json" \
-#              "https://api.github.com/repos/${{ github.repository }}/releases" \
-#              -d "{\"tag_name\": \"snapshot-diff\", \"name\": \"$RELEASE_NAME\", \"body\": \"Snapshot diff images\"}")
-#            RELEASE_ID=$(echo "$RESPONSE" | jq -r '.id')
-#          else
-#            echo "Release already exists. Using ID: $EXISTING_RELEASE"
-#            RELEASE_ID=$EXISTING_RELEASE
-#          fi
-#      
-#          echo "RELEASE_ID=$RELEASE_ID" >> $GITHUB_ENV
-
-#      - name: 必要なツールをインストール
-#        if: failure()
-#        run: |
-#          sudo apt-get update
-#          sudo apt-get install -y jq curl
-
-#      - name: Upload success, failed, and diff images to GitHub Release
-#        if: failure()
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        run: |
-#          UPLOAD_URL="https://uploads.github.com/repos/${{ github.repository }}/releases/$RELEASE_ID/assets"
-#      
-#          # 成功画像のアップロード
-#          for file in artifacts/success/*.png; do
-#            echo "Uploading success image: $file"
-#            curl -s -X POST \
-#              -H "Authorization: token $GITHUB_TOKEN" \
-#              -H "Content-Type: application/octet-stream" \
-#              "$UPLOAD_URL?name=success_$(basename "$file")" \
-#              --data-binary @"$file"
-#          done
-#      
-#          # 失敗画像のアップロード
-#          for file in artifacts/failed/*.png; do
-#            echo "Uploading failed image: $file"
-#            curl -s -X POST \
-#              -H "Authorization: token $GITHUB_TOKEN" \
-#              -H "Content-Type: application/octet-stream" \
-#              "$UPLOAD_URL?name=failed_$(basename "$file")" \
-#              --data-binary @"$file"
-#          done
-#      
-#          # 差分画像のアップロード
-#          for file in artifacts/diffs/*.png; do
-#            echo "Uploading diff image: $file"
-#            curl -s -X POST \
-#              -H "Authorization: token $GITHUB_TOKEN" \
-#              -H "Content-Type: application/octet-stream" \
-#              "$UPLOAD_URL?name=$(basename "$file")" \
-#              --data-binary @"$file"
-#          done
-
-#      - name: Comment on PR with structured snapshot diffs from Release
-#        if: failure()
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        run: |
-#          RELEASE_URL="https://github.com/${{ github.repository }}/releases/download/snapshot-diff"
-#      
-#          # コメント本文の構築
-#          COMMENT_BODY=$(cat <<EOF
-#          🚨 **Snapshotテストで差分が発生しています** 🚨
-#    
-#          以下に画像の差分を表示します。
-#    
-#          詳細な画像はこちらからダウンロードしてください。
-#          [📥 Artifactsをダウンロード](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)
-#    
-#          EOF
-#          )
-#    
-#              for file in artifacts/diffs/*.png; do
-#                BASENAME=$(basename "$file")
-#                FILENAME=${BASENAME#diff_}  # "diff_" を削除して元のファイル名を取得
-#                DIFF_IMAGE_URL="$RELEASE_URL/$BASENAME"
-#                SUCCESS_IMAGE_URL="$RELEASE_URL/success_${FILENAME}"
-#                FAILED_IMAGE_URL="$RELEASE_URL/failed_${FILENAME}"
-#    
-#                COMMENT_BODY+=$(cat <<EOF
-#    
-#          ### ${FILENAME}
-#    
-#          | 既存 | 差分 | 今回の変更 |
-#          | -- | -- | -- |
-#          | <img src="${SUCCESS_IMAGE_URL}" width="300"> | <img src="${DIFF_IMAGE_URL}" width="300"> | <img src="${FAILED_IMAGE_URL}" width="300"> |
-#    
-#          EOF
-#          )
-#              done
-#    
-#              # JSONエスケープを適用し GitHub API に送信
-#              curl -X POST \
-#                -H "Authorization: token $GITHUB_TOKEN" \
-#                -H "Accept: application/vnd.github+json" \
-#                "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-#                -d "$(jq -Rs --arg body "$COMMENT_BODY" '{body: $body}' <<< "")"
-
-      # Issueにあげて公開URLを取得すると良さそう
       - name: Cache VRT snapshots
         if: always()
         uses: actions/cache/save@v3

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -140,7 +140,7 @@ jobs:
 #          name: snapshot-diffs
 #          path: artifacts/diffs/*.png
 
-      - name: Upload diff images to Issue and comment on PR
+      - name: Upload diff images via Markdown API and comment on PR
         if: failure()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -148,29 +148,26 @@ jobs:
           COMMENT_BODY="🚨 **Snapshotテストで差分が発生しています** 🚨\n\n"
       
           for file in artifacts/diffs/*.png; do
-            echo "Uploading $file to GitHub Issue..."
+            echo "Uploading $file to GitHub via Markdown API..."
             
-            # 1️⃣ GitHub の Markdown API を使って画像をアップロード
-            UPLOAD_RESPONSE=$(curl -s -X POST \
+            # 1️⃣ GitHubのMarkdown APIを使って画像をアップロード
+            RESPONSE=$(curl -s -X POST \
               -H "Authorization: token $GITHUB_TOKEN" \
-              -H "Accept: application/vnd.github+json" \
-              -H "Content-Type: $(file -b --mime-type "$file")" \
-              --data-binary @"$file" \
-              "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments")
-      
-            # 2️⃣ 画像のURLを抽出
-            IMAGE_URL=$(echo "$UPLOAD_RESPONSE" | jq -r '.html_url')
-      
+              -H "Accept: application/vnd.github.v3+json" \
+              -d "{\"text\":\"![Uploading $file...](https://github.com)\"}" \
+              "https://api.github.com/markdown")
+            
+            IMAGE_URL=$(echo "$RESPONSE" | grep -o 'https://user-images.githubusercontent.com[^)]*' | head -n1)
+            
             if [[ -z "$IMAGE_URL" || "$IMAGE_URL" == "null" ]]; then
               echo "Failed to upload $file"
               exit 1
             fi
-
-            # 3️⃣ コメント本文に画像を追加
+            
             COMMENT_BODY+="![Diff Image $(basename "$file")]($IMAGE_URL)\n\n"
           done
       
-          # 4️⃣ 画像リンクを含むコメントをPRに投稿
+          # 2️⃣ PRにコメントを投稿
           ESCAPED_BODY=$(echo "$COMMENT_BODY" | jq -Rs .)
       
           curl -X POST \

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -140,27 +140,39 @@ jobs:
 #          name: snapshot-diffs
 #          path: artifacts/diffs/*.png
 
-      - name: Upload diff images to Issue comment
+      - name: Upload diff images to Issue and comment on PR
         if: failure()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           COMMENT_BODY="🚨 **Snapshotテストで差分が発生しています** 🚨\n\n"
-
+      
           for file in artifacts/diffs/*.png; do
-            RESPONSE=$(curl -s -X POST \
+            echo "Uploading $file to GitHub Issue..."
+            
+            # 1️⃣ GitHub の Markdown API を使って画像をアップロード
+            UPLOAD_RESPONSE=$(curl -s -X POST \
               -H "Authorization: token $GITHUB_TOKEN" \
               -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-              -d "{\"body\": \"![Diff Image $(basename \"$file\")]()\"}")
+              -H "Content-Type: $(file -b --mime-type "$file")" \
+              --data-binary @"$file" \
+              "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments")
+      
+            # 2️⃣ 画像のURLを抽出
+            IMAGE_URL=$(echo "$UPLOAD_RESPONSE" | jq -r '.html_url')
+      
+            if [[ -z "$IMAGE_URL" || "$IMAGE_URL" == "null" ]]; then
+              echo "Failed to upload $file"
+              exit 1
+            fi
 
-            URL=$(echo "$RESPONSE" | jq -r '.body' | grep -Eo 'https://user-images.githubusercontent.com[^)]+' | head -n1)
-
-            COMMENT_BODY+="![Diff Image $(basename \"$file\")]($URL)\n\n"
+            # 3️⃣ コメント本文に画像を追加
+            COMMENT_BODY+="![Diff Image $(basename "$file")]($IMAGE_URL)\n\n"
           done
-
+      
+          # 4️⃣ 画像リンクを含むコメントをPRに投稿
           ESCAPED_BODY=$(echo "$COMMENT_BODY" | jq -Rs .)
-
+      
           curl -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -193,7 +193,7 @@ jobs:
     
           ### ${FILENAME}
     
-          | 既存（成功時） | 差分 | 新規（失敗時） |
+          | 既存 | 差分 | 今回の変更 |
           | -- | -- | -- |
           | <img src="${SUCCESS_IMAGE_URL}" width="300"> | <img src="${DIFF_IMAGE_URL}" width="300"> | <img src="${FAILED_IMAGE_URL}" width="300"> |
     

--- a/citest02.xcodeproj/project.pbxproj
+++ b/citest02.xcodeproj/project.pbxproj
@@ -27,14 +27,38 @@
 		5344E3FA2D6F2CC400DDDBC4 /* citest02Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = citest02Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		53B0D05D2D75CE89000FE184 /* Exceptions for "citest02Tests" folder in "citest02Tests" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				__Snapshots__/citest02Tests/example.1.png,
+			);
+			target = 5344E3F92D6F2CC400DDDBC4 /* citest02Tests */;
+		};
+		53B0D06D2D7844E0000FE184 /* Exceptions for "citest02" folder in "citest02" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Snapshots/__Snapshots__/SnapshotFilePath/example.1.png,
+				Snapshots/__Snapshots__/SnapshotFilePath/example2.1.png,
+			);
+			target = 5344E3E92D6F2CC300DDDBC4 /* citest02 */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		5344E3EC2D6F2CC300DDDBC4 /* citest02 */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				53B0D06D2D7844E0000FE184 /* Exceptions for "citest02" folder in "citest02" target */,
+			);
 			path = citest02;
 			sourceTree = "<group>";
 		};
 		5344E3FD2D6F2CC400DDDBC4 /* citest02Tests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				53B0D05D2D75CE89000FE184 /* Exceptions for "citest02Tests" folder in "citest02Tests" target */,
+			);
 			path = citest02Tests;
 			sourceTree = "<group>";
 		};

--- a/citest02Tests/citest02Tests.swift
+++ b/citest02Tests/citest02Tests.swift
@@ -16,7 +16,7 @@ struct citest02Tests {
     @MainActor
     @Test func example() async throws {
         assertSnapshot(
-            of: Text("テスト\nテスト").referenceFrame(),
+            of: Text("テスト\nテスト\nテスト").referenceFrame(),
             as: .wait(
                 for: 0,  // スクショまでの時間
                 on: .image(
@@ -34,7 +34,7 @@ struct citest02Tests {
     @MainActor
     @Test func example2() async throws {
         assertSnapshot(
-            of: Text("テスト\nテスト").referenceFrame(),
+            of: Text("テスト\nテスト\nテスト").referenceFrame(),
             as: .wait(
                 for: 0,  // スクショまでの時間
                 on: .image(

--- a/citest02Tests/citest02Tests.swift
+++ b/citest02Tests/citest02Tests.swift
@@ -16,7 +16,7 @@ struct citest02Tests {
     @MainActor
     @Test func example() async throws {
         assertSnapshot(
-            of: Text("テストa").referenceFrame(),
+            of: Text("テスト\nテスト").referenceFrame(),
             as: .wait(
                 for: 0,  // スクショまでの時間
                 on: .image(
@@ -34,7 +34,7 @@ struct citest02Tests {
     @MainActor
     @Test func example2() async throws {
         assertSnapshot(
-            of: Text("テスト").referenceFrame(),
+            of: Text("テスト\nテスト").referenceFrame(),
             as: .wait(
                 for: 0,  // スクショまでの時間
                 on: .image(

--- a/citest02Tests/citest02Tests.swift
+++ b/citest02Tests/citest02Tests.swift
@@ -16,7 +16,7 @@ struct citest02Tests {
     @MainActor
     @Test func example() async throws {
         assertSnapshot(
-            of: Text("テスト\nテスト\nテスト").referenceFrame(),
+            of: Text("テスト").referenceFrame(),
             as: .wait(
                 for: 0,  // スクショまでの時間
                 on: .image(
@@ -34,7 +34,7 @@ struct citest02Tests {
     @MainActor
     @Test func example2() async throws {
         assertSnapshot(
-            of: Text("テスト\nテスト\nテスト").referenceFrame(),
+            of: Text("テスト\nテスト").referenceFrame(),
             as: .wait(
                 for: 0,  // スクショまでの時間
                 on: .image(


### PR DESCRIPTION
テストケース名が画像名となるので、それをデザイン側と揃えておくと確認が楽

## アーキテクチャ
![image](https://github.com/user-attachments/assets/202e073f-2e08-47a9-bfea-a860c2ce98b3)

## 検討・採用したもの
- テストオラクルな画像はCacheに保存
  - デフォルトで7日間
  - 10GBの容量
  - [document](https://cli.github.com/manual/gh_cache_delete)
- PRに表示するための「既存・差分・今回」の画像は Compare_Feature ブランチにコミット
  - マージ後削除
- 一定期間、履歴を残すためにartifactに保存
  - Compare_Featureブランチはマージ後に削除されるため、履歴を残しておく (なくて良いかも...)
  - artifactはデフォルトで90日間保存
  - artifactごとに2GBまでの制限
  - artifactは各コミットに対して紐づいている

## 検討したがNGになったもの
- Releasesに画像アップロード
  - Github CLI で唯一 upload を持つが、利用意図と異なるためNG
- Issueに画像アップロード
  - Github CLI に upload がないためNG
- ビジュアライズにreg-suitの利用
  - 外部サービスに依存したくないためNG
  - PR上で直接確認したいためNG
- S3にアップロード
  - 外部サービスに依存したくないためNG
  - Githubのエコシステムで完結した方がI/Oも早い
